### PR TITLE
openlog api proxy user with executeUser

### DIFF
--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/index.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/index.vue
@@ -368,7 +368,7 @@ export default {
         fileName
       }
       if (this.isAdminModel) {
-        query.executeUser = params.row.executeUser
+        query.proxyUser = params.row.executeUser
       }
       storage.set('last-searchbar-status', this.searchBar)
       storage.set('last-pageSetting-status', this.pageSetting)

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/index.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/index.vue
@@ -368,7 +368,7 @@ export default {
         fileName
       }
       if (this.isAdminModel) {
-        query.proxyUser = params.row.umUser
+        query.executeUser = params.row.executeUser
       }
       storage.set('last-searchbar-status', this.searchBar)
       storage.set('last-pageSetting-status', this.pageSetting)

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -306,7 +306,7 @@ export default {
           path: jobhistory.task.logPath
         }
         if (this.$route.query.proxyUser) {
-          params.proxyUser = this.$route.query.executeUser
+          params.proxyUser = this.$route.query.proxyUser
         }
         let openLog = {}
         if (this.$route.query.status === 'Scheduled' || this.$route.query.status === 'Running') {

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -305,8 +305,8 @@ export default {
         const params = {
           path: jobhistory.task.logPath
         }
-        if (this.$route.query.proxyUser) {
-          params.proxyUser = this.$route.query.proxyUser
+        if (this.$route.query.executeUser) {
+          params.executeUser = this.$route.query.executeUser
         }
         let openLog = {}
         if (this.$route.query.status === 'Scheduled' || this.$route.query.status === 'Running') {

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -305,8 +305,8 @@ export default {
         const params = {
           path: jobhistory.task.logPath
         }
-        if (this.$route.query.executeUser) {
-          params.executeUser = this.$route.query.executeUser
+        if (this.$route.query.proxyUser) {
+          params.proxyUser = this.$route.query.executeUser
         }
         let openLog = {}
         if (this.$route.query.status === 'Scheduled' || this.$route.query.status === 'Running') {

--- a/linkis-web/src/common/service/api.js
+++ b/linkis-web/src/common/service/api.js
@@ -164,7 +164,7 @@ const success = function(response) {
     let code = res.codePath;
     let message = res.messagePath;
     let result = res.resultPath;
-    let errorMsgTip = result.errorMsgTip;
+    let errorMsgTip = result ? result.errorMsgTip : '';
     if (errorMsgTip) {
       sessionStorage.setItem('linkis.errorMsgTip', errorMsgTip)
     }

--- a/linkis-web/src/dss/view/logPage/index.vue
+++ b/linkis-web/src/dss/view/logPage/index.vue
@@ -91,7 +91,7 @@ export default {
         }
         this.params = {
           path: res.task.logPath,
-          // proxyUser: res.task.umUser
+          // executeUser: res.task.executeUser
         };
         this.getLogs(this.params);
       }).catch(() => {

--- a/linkis-web/src/dss/view/logPage/index.vue
+++ b/linkis-web/src/dss/view/logPage/index.vue
@@ -5,16 +5,16 @@
   ~ The ASF licenses this file to You under the Apache License, Version 2.0
   ~ (the "License"); you may not use this file except in compliance with
   ~ the License.  You may obtain a copy of the License at
-  ~ 
+  ~
   ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~ 
+  ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-  
+
 <template>
   <div class="log-content">
     <div class="header-bar">
@@ -91,7 +91,7 @@ export default {
         }
         this.params = {
           path: res.task.logPath,
-          // executeUser: res.task.executeUser
+          // proxyUser: res.task.executeUser
         };
         this.getLogs(this.params);
       }).catch(() => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

openlog api proxy user with executeUser



### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
