### PR TITLE
Adapt data source script fallback

### DIFF
--- a/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/conf/RPCConfiguration.scala
+++ b/linkis-commons/linkis-rpc/src/main/scala/org/apache/linkis/rpc/conf/RPCConfiguration.scala
@@ -86,7 +86,7 @@ object RPCConfiguration {
   val LINKIS_DATASOURCE_SERVICE_LIST: Array[String] =
     CommonVars(
       "linkis.gateway.conf.linkisdatasource.list",
-      "data-source-manager,metadataquery,datasource"
+      "datasource"
     ).getValue
       .split(",")
 


### PR DESCRIPTION
### What is the purpose of the change

The commercial database data source script needs to be rolled back, and the forwarding logic also needs to be rolled back

### Related issues/PRs

Related issues: omit
Related pr: https://github.com/WeDataSphere/linkis/pull/189


