### PR TITLE
fix Extra invisible characters

### DIFF
--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.filesystem.restful.api;
 
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.linkis.common.conf.Configuration;
 import org.apache.linkis.common.io.FsPath;
 import org.apache.linkis.common.io.FsWriter;
@@ -954,7 +955,10 @@ public class FsRestfulApi {
         res.put("sheetName", info.get(0));
       } else {
         String[][] column = null;
-        BufferedReader reader = new BufferedReader(new InputStreamReader(in, encoding));
+        //fix csv file with utf-8 with bom chart[&#xFEFF]
+        BOMInputStream bomIn = new BOMInputStream(in, false); // don't include the BOM
+        BufferedReader reader = new BufferedReader(new InputStreamReader(bomIn, encoding));
+
         String header = reader.readLine();
         if (StringUtils.isEmpty(header)) {
           throw WorkspaceExceptionManager.createException(80016);


### PR DESCRIPTION
### What is the purpose of the change

When importing hive, when reading field characters, an invisible character was found. The ASCII code of the first character read in UTF8+BOM file format is 65279, which needs to be processed by the backend
![image](https://github.com/WeDataSphere/linkis/assets/129247228/461010f6-6218-4c5a-8912-20011ec1897d)


### Related issues/PRs

Related pr: https://github.com/WeDataSphere/linkis/pull/240

Expect：
![image](https://github.com/WeDataSphere/linkis/assets/129247228/b7d38937-5dc9-4c9a-9dfa-18f25aaab126)




