### PR TITLE
【1.1.14】code view fix

### DIFF
--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/entity/ConfigUserValue.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/entity/ConfigUserValue.java
@@ -22,7 +22,7 @@ public class ConfigUserValue {
   private String key;
 
   private String name;
-
+  //  linkis_ps_configuration_config_key  id
   private Integer configKeyId;
 
   private String description;
@@ -30,11 +30,11 @@ public class ConfigUserValue {
   private String defaultValue;
 
   private String engineType;
-
+  //  linkis_ps_configuration_config_value id
   private Integer configValueId;
 
   private String configValue;
-
+  //  linkis_cg_manager_label id
   private Integer configLabelId;
 
   private String labelValue;

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/errorcode/LinkisConfigurationErrorCodeSummary.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/errorcode/LinkisConfigurationErrorCodeSummary.java
@@ -41,7 +41,7 @@ public enum LinkisConfigurationErrorCodeSummary implements LinkisErrorCode {
       14100,
       "The saved engine type parameter is incorrect, please send it in a fixed format, such as spark-2.4.3(保存的引擎类型参数有误，请按照固定格式传送，例如spark-2.4.3)"),
   INCOMPLETE_RECONFIRM(14100, "Incomplete request parameters, please reconfirm(请求参数不完整，请重新确认)"),
-  ONLY_ADMIN_CAN_MODIFY(14100, "Only admin have permission to perform this operation(限管理员执行此操作)"),
+  ONLY_ADMIN_PERFORM(14100, "Only admin have permission to perform this operation(限管理员执行此操作)"),
   THE_LABEL_PARAMETER_IS_EMPTY(14100, " The label parameter is empty(标签参数为空)"),
   ERROR_VALIDATOR_RANGE(14100, "Error validator range！(错误验证器范围！)"),
   TYPE_OF_LABEL_NOT_SUPPORTED(14100, "This type of label is not supported:{0}(不支持这种类型的标签：{0})");

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
@@ -478,7 +478,7 @@ public class ConfigurationRestfulApi {
     String configKey = (String) json.get("configKey");
     String value = (String) json.get("configValue");
     boolean force = Boolean.parseBoolean(json.getOrDefault("force", "false").toString());
-    if (!org.apache.linkis.common.conf.Configuration.isAdmin(username) && username.equals(user)) {
+    if (!org.apache.linkis.common.conf.Configuration.isAdmin(username) && !username.equals(user)) {
       return Message.error("Non admin are prohibited from modifying others' data");
     }
     if (engineType.equals("*") && !version.equals("*")) {

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
@@ -171,6 +171,7 @@ public class ConfigurationRestfulApi {
       throws ConfigurationException {
     String userName =
         ModuleUserUtils.getOperationUser(req, "getItemList with engineType:" + engineType);
+    // Adding * represents returning all configuration information
     if ("*".equals(engineType)) {
       engineType = null;
     }
@@ -420,7 +421,7 @@ public class ConfigurationRestfulApi {
 
   private void checkAdmin(String userName) throws ConfigurationException {
     if (!org.apache.linkis.common.conf.Configuration.isAdmin(userName)) {
-      throw new ConfigurationException(ONLY_ADMIN_CAN_MODIFY.getErrorDesc());
+      throw new ConfigurationException(ONLY_ADMIN_PERFORM.getErrorDesc());
     }
   }
 
@@ -477,6 +478,9 @@ public class ConfigurationRestfulApi {
     String configKey = (String) json.get("configKey");
     String value = (String) json.get("configValue");
     boolean force = Boolean.parseBoolean(json.getOrDefault("force", "false").toString());
+    if (!org.apache.linkis.common.conf.Configuration.isAdmin(username) && username.equals(user)) {
+      return Message.error("Non admin are prohibited from modifying others' data");
+    }
     if (engineType.equals("*") && !version.equals("*")) {
       return Message.error("When engineType is any engine, the version must also be any version");
     }
@@ -591,7 +595,7 @@ public class ConfigurationRestfulApi {
 
   @ApiOperation(value = "saveBaseKeyValue", notes = "save key", response = Message.class)
   @ApiImplicitParams({
-    @ApiImplicitParam(name = "id", required = false, dataType = "String", value = "id"),
+    @ApiImplicitParam(name = "id", required = false, dataType = "Integer", value = "id"),
     @ApiImplicitParam(name = "key", required = true, dataType = "String", value = "key"),
     @ApiImplicitParam(name = "name", required = true, dataType = "String", value = "name"),
     @ApiImplicitParam(

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/ConfigurationRestfulApi.java
@@ -479,7 +479,7 @@ public class ConfigurationRestfulApi {
     String value = (String) json.get("configValue");
     boolean force = Boolean.parseBoolean(json.getOrDefault("force", "false").toString());
     if (!org.apache.linkis.common.conf.Configuration.isAdmin(username) && !username.equals(user)) {
-      return Message.error("Non admin are prohibited from modifying others' data");
+      return Message.error("Only admin can modify other user configuration data");
     }
     if (engineType.equals("*") && !version.equals("*")) {
       return Message.error("When engineType is any engine, the version must also be any version");

--- a/linkis-public-enhancements/linkis-configuration/src/main/resources/mapper/common/ConfigMapper.xml
+++ b/linkis-public-enhancements/linkis-configuration/src/main/resources/mapper/common/ConfigMapper.xml
@@ -378,7 +378,7 @@
             <if test="engineType != null">`engine_conn_type` = #{engineType}</if>
             <if test="key != null">and `key` like concat('%',#{key},'%')</if>
         </where>
-        order by engine_conn_type
+        ORDER BY engine_conn_type
     </select>
 
 
@@ -392,7 +392,7 @@
             <if test="engineType != null">`engine_conn_type` = #{engineType}</if>
             <if test="key != null">and `key` like concat('%',#{key},'%')</if>
         </where>
-        order by engine_conn_type
+        ORDER BY engine_conn_type
     </select>
 
 
@@ -415,39 +415,44 @@
             linkis_ps_configuration_config_key config,
             linkis_ps_configuration_config_value config_value,
             (
-            SELECT
-                managerlabel.id, managerlabel .label_value, SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",", 1), "-", 1) as username, SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",", 1), "-",-1) as creator, SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",",-1), "-", 1) as enginetype, SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",",-1), "-",-1) as engineversion
-            FROM
-                linkis_cg_manager_label managerlabel
-            WHERE
-                managerlabel.label_key = "combined_userCreator_engineType") label
+                SELECT
+                    managerlabel.id,
+                    managerlabel .label_value,
+                    SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",", 1), "-", 1) as username,
+                    SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",", 1), "-",-1) as creator,
+                    SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",",-1), "-", 1) as enginetype,
+                    SUBSTRING_INDEX(SUBSTRING_INDEX(label_value, ",",-1), "-",-1) as engineversion
+                FROM
+                    linkis_cg_manager_label managerlabel
+                WHERE
+                    managerlabel.label_key = "combined_userCreator_engineType"
+            ) label
         <where>
         config_value.config_key_id = config.id
-        and config_value.config_label_id = label .id
+        AND config_value.config_label_id = label .id
             <if test="key != null">AND config.`key` like concat('%',#{key},'%')</if>
             <if test="user != null">AND label.username = #{user} </if>
             <if test="creator != null">AND LOWER(label.creator) = LOWER(#{creator}) </if>
             <if test="engineType != null">AND label.engineType = #{engineType} </if>
         </where>
-        ORDER BY
-        engine_conn_type
+        ORDER BY engine_conn_type
     </select>
 
     <insert id="insertKeyByBase" useGeneratedKeys="true" keyProperty="id" parameterType="org.apache.linkis.configuration.entity.ConfigKey">
         INSERT INTO linkis_ps_configuration_config_key (
-        `key`, `description`,
-        `name`, `engine_conn_type`, `default_value`,
-        `validate_type`, `validate_range`, `is_hidden`,
-        `is_advanced`, `level`, `treeName`,
-        `boundary_type`, `en_name`, `en_treeName`,
-        `en_description`)
+            `key`, `description`, `name`,
+            `engine_conn_type`, `default_value`, `validate_type`,
+            `validate_range`, `is_hidden`, `is_advanced`,
+            `level`, `treeName`, `boundary_type`,
+            `en_name`, `en_treeName`, `en_description`
+        )
         VALUES (
-        #{key}, #{description},
-        #{name}, #{engineType}, #{defaultValue},
-        #{validateType}, #{validateRange}, #{isHidden},
-        #{isAdvanced}, #{level}, #{treeName},
-        #{boundaryType}, #{enName}, #{enTreeName},
-        #{enDescription})
+            #{key}, #{description}, #{name},
+            #{engineType}, #{defaultValue}, #{validateType},
+            #{validateRange}, #{isHidden}, #{isAdvanced},
+            #{level}, #{treeName}, #{boundaryType},
+            #{enName}, #{enTreeName}, #{enDescription}
+        )
     </insert>
 
     <update id="updateConfigKey"  parameterType="org.apache.linkis.configuration.entity.ConfigKey">


### PR DESCRIPTION
1.ONLY ADMIN CAN MODIFY for log blocking
2.The special logic of the getItemList interface needs to be annotated
3.Keyvalue post: Non administrators can only modify their own
4.Swagger API annotation types should be correct