### PR TITLE
Fix linkis cli npe error

### DIFF
--- a/linkis-computation-governance/linkis-client/linkis-cli/src/main/java/org/apache/linkis/cli/application/interactor/job/interactive/InteractiveJob.java
+++ b/linkis-computation-governance/linkis-client/linkis-cli/src/main/java/org/apache/linkis/cli/application/interactor/job/interactive/InteractiveJob.java
@@ -88,17 +88,17 @@ public class InteractiveJob implements Job {
     LinkisOperResultAdapter jobInfoResult =
         oper.queryJobInfo(submitResult.getUser(), submitResult.getJobID());
     oper.queryJobStatus(
-        jobInfoResult.getUser(), jobInfoResult.getJobID(), jobInfoResult.getStrongerExecId());
+        submitResult.getUser(), submitResult.getJobID(), submitResult.getStrongerExecId());
     infoBuilder.setLength(0);
     infoBuilder
         .append("JobId:")
-        .append(jobInfoResult.getJobID())
+        .append(submitResult.getJobID())
         .append(System.lineSeparator())
         .append("TaskId:")
-        .append(jobInfoResult.getJobID())
+        .append(submitResult.getJobID())
         .append(System.lineSeparator())
         .append("ExecId:")
-        .append(jobInfoResult.getStrongerExecId());
+        .append(submitResult.getStrongerExecId());
     LoggerManager.getPlaintTextLogger().info(infoBuilder.toString());
     infoBuilder.setLength(0);
 
@@ -137,7 +137,7 @@ public class InteractiveJob implements Job {
     logRetriever.retrieveLogAsync();
 
     // wait complete
-    jobInfoResult = waitJobComplete(submitResult.getUser(), submitResult.getJobID());
+    jobInfoResult = waitJobComplete(submitResult.getUser(), submitResult.getJobID(), submitResult.getStrongerExecId());
     logRetriever.waitIncLogComplete();
 
     // get result-set
@@ -205,20 +205,20 @@ public class InteractiveJob implements Job {
     return result;
   }
 
-  private LinkisOperResultAdapter waitJobComplete(String user, String jobId)
+  private LinkisOperResultAdapter waitJobComplete(String user, String jobId, String execId)
       throws LinkisClientRuntimeException {
     int retryCnt = 0;
     final int MAX_RETRY = 30;
 
     LinkisOperResultAdapter jobInfoResult = oper.queryJobInfo(user, jobId);
-    oper.queryJobStatus(user, jobId, jobInfoResult.getStrongerExecId());
+    oper.queryJobStatus(user, jobId, execId);
 
     while (!jobInfoResult.getJobStatus().isJobFinishedState()) {
       // query progress
       try {
         jobInfoResult = oper.queryJobInfo(user, jobId);
         oper.queryJobStatus(
-            jobInfoResult.getUser(), jobInfoResult.getJobID(), jobInfoResult.getStrongerExecId());
+            jobInfoResult.getUser(), jobInfoResult.getJobID(), execId);
       } catch (Exception e) {
         logger.warn("", e);
         retryCnt++;

--- a/linkis-computation-governance/linkis-client/linkis-cli/src/main/java/org/apache/linkis/cli/application/operator/ujes/LinkisJobOper.java
+++ b/linkis-computation-governance/linkis-client/linkis-cli/src/main/java/org/apache/linkis/cli/application/operator/ujes/LinkisJobOper.java
@@ -127,7 +127,7 @@ public class LinkisJobOper implements JobOper {
       //      jobExecuteResult = client.execute(jobExecuteAction);
 
       jobSubmitResult = client.submit(jobSubmitAction);
-      logger.info("Response info from Linkis: \n{}", CliUtils.GSON.toJson(jobSubmitAction));
+      logger.info("Response info from Linkis: \n{}", CliUtils.GSON.toJson(jobSubmitResult));
 
     } catch (Exception e) {
       // must throw if exception

--- a/linkis-computation-governance/linkis-client/linkis-cli/src/main/java/org/apache/linkis/cli/application/operator/ujes/UJESResultAdapter.java
+++ b/linkis-computation-governance/linkis-client/linkis-cli/src/main/java/org/apache/linkis/cli/application/operator/ujes/UJESResultAdapter.java
@@ -162,6 +162,10 @@ public class UJESResultAdapter implements LinkisOperResultAdapter {
       return null;
     }
     String execId = null;
+
+    if (result instanceof JobSubmitResult) {
+      execId = ((JobSubmitResult) result).getExecID();
+    }
     if (result instanceof JobInfoResult) {
       if (result != null
           && ((JobInfoResult) result).getTask() != null


### PR DESCRIPTION
What is the purpose of the change
fix bug :When a task is submitted concurrently, the linkis-cli client reports a null pointer and exits abnormally, and the background of the task runs normally

Related issues/PRs
Related issues: https://github.com/apache/linkis/issues/4918

Brief change log
Adjustment [linkis-cli] module InteractiveJob/LinkisJobOper/UJESResultAdapter of three classes