### PR TITLE
Fix excel load into hive & log optimize

### DIFF
--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/java/org/apache/linkis/governance/common/constant/CodeConstants.java
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/java/org/apache/linkis/governance/common/constant/CodeConstants.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.governance.common.constant;
+
+public class CodeConstants {
+  // will auto append at end of scala code; make sure the last line is not a comment
+  public static String SCALA_CODE_AUTO_APPEND_CODE = "val linkisVar=123";
+}

--- a/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
+++ b/linkis-computation-governance/linkis-computation-governance-common/src/main/scala/org/apache/linkis/governance/common/paser/CodeParser.scala
@@ -19,6 +19,7 @@ package org.apache.linkis.governance.common.paser
 
 import org.apache.linkis.common.utils.{CodeAndRunTypeUtils, Logging, Utils}
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf
+import org.apache.linkis.governance.common.constant.CodeConstants
 import org.apache.linkis.governance.common.paser.CodeType.CodeType
 
 import org.apache.commons.lang3.StringUtils
@@ -116,7 +117,7 @@ class ScalaCodeParser extends SingleCodeParser with Logging {
     if (statementBuffer.nonEmpty) codeBuffer.append(statementBuffer.mkString("\n"))
     // Make sure the last line is not a comment
     codeBuffer.append("\n")
-    codeBuffer.append("val linkisVar=123")
+    codeBuffer.append(CodeConstants.SCALA_CODE_AUTO_APPEND_CODE)
     codeBuffer.toArray
   }
 

--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/java/org/apache/linkis/engineconn/computation/concurrent/monitor/TimingMonitorService.java
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/java/org/apache/linkis/engineconn/computation/concurrent/monitor/TimingMonitorService.java
@@ -96,7 +96,7 @@ public class TimingMonitorService implements InitializingBean, Runnable {
       } else {
         if (concurrentExecutor.isIdle())
           synchronized (EXECUTOR_STATUS_LOCKER) {
-            LOG.info("monitor turn to executor status from busy to unlock");
+            LOG.info("monitor turn to executor status from unlock to busy");
             concurrentExecutor.transition(NodeStatus.Busy);
           }
       }

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/label/MultiUserEngineReuseLabelChooser.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/label/MultiUserEngineReuseLabelChooser.scala
@@ -71,7 +71,7 @@ class MultiUserEngineReuseLabelChooser extends EngineReuseLabelChooser with Logg
         val userAdmin = userMap.get(engineTypeLabel.getEngineType)
         val userCreatorLabel = userCreatorLabelOption.get.asInstanceOf[UserCreatorLabel]
         logger.info(
-          s"For multi user engine to reset userCreatorLabel user ${userCreatorLabel.getUser} to Admin $userAdmin "
+          s"For multi user engine to reset userCreatorLabel user ${userCreatorLabel.getUser} to admin $userAdmin "
         )
         userCreatorLabel.setUser(userAdmin)
         return labels.asJava

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPostExecutionHook.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPostExecutionHook.scala
@@ -22,6 +22,8 @@ import org.apache.linkis.engineconn.computation.executor.execute.EngineExecution
 import org.apache.linkis.engineplugin.spark.common.SparkKind
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.extension.SparkPostExecutionHook
+import org.apache.linkis.governance.common.constant.CodeConstants
+import org.apache.linkis.governance.common.constant.job.TaskInfoConstants
 import org.apache.linkis.manager.label.entity.engine.CodeLanguageLabel
 import org.apache.linkis.protocol.mdq.{DDLCompleteResponse, DDLExecuteResponse}
 import org.apache.linkis.rpc.Sender
@@ -49,6 +51,12 @@ class MDQPostExecutionHook extends SparkPostExecutionHook with Logging {
       executeResponse: ExecuteResponse,
       code: String
   ): Unit = {
+    if (StringUtils.isBlank(code)) {
+      return
+    }
+    if (CodeConstants.SCALA_CODE_AUTO_APPEND_CODE.equalsIgnoreCase(code.trim)) {
+      return
+    }
     val codeLanguageLabel = engineExecutionContext.getLabels
       .filter(l => null != l && l.isInstanceOf[CodeLanguageLabel])
       .head

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPreExecutionHook.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPreExecutionHook.scala
@@ -24,13 +24,15 @@ import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.errorcode.SparkErrorCodeSummary._
 import org.apache.linkis.engineplugin.spark.exception.MDQErrorException
 import org.apache.linkis.engineplugin.spark.extension.SparkPreExecutionHook
+import org.apache.linkis.governance.common.constant.CodeConstants
 import org.apache.linkis.manager.label.entity.engine.CodeLanguageLabel
 import org.apache.linkis.protocol.mdq.{DDLRequest, DDLResponse}
 import org.apache.linkis.rpc.Sender
 import org.apache.linkis.storage.utils.StorageUtils
 
+import org.apache.commons.lang3.StringUtils
+
 import org.springframework.stereotype.Component
-import org.springframework.util.StringUtils
 
 import javax.annotation.PostConstruct
 
@@ -63,6 +65,13 @@ class MDQPreExecutionHook extends SparkPreExecutionHook with Logging {
     if (StringUtils.isEmpty(runType) || !SparkKind.FUNCTION_MDQ_TYPE.equalsIgnoreCase(runType)) {
       return code
     }
+    if (StringUtils.isBlank(code)) {
+      return code
+    }
+    if (CodeConstants.SCALA_CODE_AUTO_APPEND_CODE.equalsIgnoreCase(code.trim)) {
+      return code
+    }
+
     val sender = Sender.getSender(SparkConfiguration.MDQ_APPLICATION_NAME.getValue)
     val params = new util.HashMap[String, Object]()
     params.put("user", StorageUtils.getJvmUser)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

Fix excel load into hive & log optimize

The additional scala code ‘ val linkisVar=123’  causes some exception 

```
scala> val source = """{"path":"/mnt/bdap/hadoop/casionxia/linkis1117_sheet.xlsx","pathType":"share","hasHeader":true,"encoding":"","fieldDelimiter":"","sheet":"datanull","quote":"","escapeQuotes":false}"""
val destination = """{"database":"aa999_ind","tableName":"aa_test","importData":false,"isPartition":1,"partition":"ds","partitionValue":"20231113","isOverwrite":false,"columns":[{"name":"a","index":0,"comment":"","type":"string","length":"","scale":"","precision":"","dateFormat":""},{"name":"b","index":1,"comment":"","type":"string","length":"","scale":"","precision":"","dateFormat":""},{"name":"c","index":2,"comment":"","type":"string","length":"","scale":"","precision":"","dateFormat":""},{"name":"d","index":3,"comment":"","type":"string","length":"","scale":"","precision":"","dateFormat":""}]}"""
org.apache.linkis.engineplugin.spark.imexport.LoadData.loadDataToTable(spark,source,destination)
scala> val linkisVar=123
2023-11-13 17:19:42.556 ERROR [Linkis-Default-Scheduler-Thread-6] org.apache.linkis.engineplugin.spark.executor.SparkScalaExecutor 118 apply [JobId-103464] - execute preExecution hook : org.apache.linkis.engineplugin.spark.mdq.MDQPreExecutionHook failed.
2023-11-13 17:19:42.558 WARN  [Linkis-Default-Scheduler-Thread-6] org.apache.linkis.engineplugin.spark.mdq.MDQPostExecutionHook 71 callPostExecutionHook [JobId-103464] - failed to execute create table:
 (执行建表失败:
)
2023-11-13 17:19:42.569 ERROR [Linkis-Default-Scheduler-Thread-6] org.apache.linkis.engineplugin.spark.executor.SparkScalaExecutor 118 apply [JobId-103464] - execute preExecution hook : org.apache.linkis.engineplugin.spark.mdq.MDQPreExecutionHook failed.
2023-11-13 17:19:42.703 WARN  [Linkis-Default-Scheduler-Thread-6] org.apache.linkis.engineplugin.spark.mdq.MDQPostExecutionHook 68 callPostExecutionHook [JobId-103464] - failed to execute create table :
val linkisVar=123 (执行建表失败):
val linkisVar=123
```

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
