### PR TITLE
[1.1.19] fix hive partition bug

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/restful/api/MdqTableRestfulApi.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/restful/api/MdqTableRestfulApi.java
@@ -31,6 +31,8 @@ import org.apache.linkis.metadata.service.MdqService;
 import org.apache.linkis.server.Message;
 import org.apache.linkis.server.utils.ModuleUserUtils;
 
+import org.apache.commons.collections.CollectionUtils;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -107,10 +109,10 @@ public class MdqTableRestfulApi {
     MetadataQueryParam queryParam =
         MetadataQueryParam.of(userName).withDbName(database).withTableName(tableName);
     List<MdqTableFieldsInfoVO> tableFieldsInfo;
-    if (mdqService.isExistInMdq(database, tableName, userName)) {
+    tableFieldsInfo = mdqService.getTableFieldsInfoFromHive(queryParam);
+    if (CollectionUtils.isEmpty(tableFieldsInfo)
+        && mdqService.isExistInMdq(database, tableName, userName)) {
       tableFieldsInfo = mdqService.getTableFieldsInfoFromMdq(database, tableName, userName);
-    } else {
-      tableFieldsInfo = mdqService.getTableFieldsInfoFromHive(queryParam);
     }
     return Message.ok().data("tableFieldsInfo", tableFieldsInfo);
   }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/restful/api/MdqTableRestfulApi.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/restful/api/MdqTableRestfulApi.java
@@ -83,11 +83,9 @@ public class MdqTableRestfulApi {
     String userName = ModuleUserUtils.getOperationUser(req, "getTableBaseInfo " + tableName);
     MetadataQueryParam queryParam =
         MetadataQueryParam.of(userName).withDbName(database).withTableName(tableName);
-    MdqTableBaseInfoVO tableBaseInfo;
-    if (mdqService.isExistInMdq(database, tableName, userName)) {
+    MdqTableBaseInfoVO tableBaseInfo = mdqService.getTableBaseInfoFromHive(queryParam);
+    if (null == tableBaseInfo && mdqService.isExistInMdq(database, tableName, userName)) {
       tableBaseInfo = mdqService.getTableBaseInfoFromMdq(database, tableName, userName);
-    } else {
-      tableBaseInfo = mdqService.getTableBaseInfoFromHive(queryParam);
     }
     return Message.ok().data("tableBaseInfo", tableBaseInfo);
   }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/service/impl/MdqServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/service/impl/MdqServiceImpl.java
@@ -110,6 +110,11 @@ public class MdqServiceImpl implements MdqService {
         mdqFieldList.remove(collect.get(1));
       }
     }
+    if (!table.getPartitionTable()) {
+      mdqFieldList.stream()
+          .filter(MdqField::getPartitionField)
+          .forEach(mdqField -> mdqField.setPartitionField(false));
+    }
     mdqDao.insertFields(mdqFieldList);
     if (mdqTableBO.getImportInfo() != null) {
       MdqTableImportInfoBO importInfo = mdqTableBO.getImportInfo();


### PR DESCRIPTION
1. When querying, first query from hive. If hive fails, then retrieve field information from the database
2. When inserting, add a check. If it is a non partitioned table, convert the field partitioning to false