### PR TITLE
[wip][1.1.20]The number of rows in the result set cannot exceed 5000 rows

### DIFF
--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/conf/WorkSpaceConfiguration.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/conf/WorkSpaceConfiguration.java
@@ -64,6 +64,8 @@ public class WorkSpaceConfiguration {
   public static final CommonVars<Boolean> ENABLE_USER_GROUP =
       CommonVars$.MODULE$.apply("linkis.os.user.group.enabled", true);
 
+  public static final CommonVars<Integer> FILESYSTEM_RESULTSET_ROW_LIMIT =
+      CommonVars$.MODULE$.apply("linkis.filesystem.resultset.row.limit", 5000);
   public static final ExecutorService executorService =
       new ThreadPoolExecutor(
           FILESYSTEM_FS_THREAD_NUM.getValue(),

--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/exception/WorkspaceExceptionManager.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/exception/WorkspaceExceptionManager.java
@@ -77,6 +77,9 @@ public class WorkspaceExceptionManager {
           put(
               "80033",
               "The log file exceeds 30MB and is too large and cannot be opened, path : {0} (日志文件超过30M，文件太大暂不支持打开查看，文件地址：{0})");
+          put(
+              "80034",
+              "The result set exceeds 5000 rows and page viewing is currently not supported. Please download to view or view in the shared directory(结果集行数超过5000行，暂不支持页面查看。请下载查看或在共享目录中查看)");
         }
       };
 

--- a/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
+++ b/linkis-public-enhancements/linkis-script-dev/linkis-storage-script-dev-server/src/main/java/org/apache/linkis/filesystem/restful/api/FsRestfulApi.java
@@ -600,6 +600,9 @@ public class FsRestfulApi {
         if (!StringUtils.isEmpty(nullValue)) {
           fileSource.addParams("nullValue", nullValue);
         }
+        if (pageSize > FILESYSTEM_RESULTSET_ROW_LIMIT.getValue()) {
+          throw WorkspaceExceptionManager.createException(80034);
+        }
         fileSource = fileSource.page(page, pageSize);
       } else if (fileSystem.getLength(fsPath)
           > ByteTimeUtils.byteStringAsBytes(FILESYSTEM_FILE_CHECK_SIZE.getValue())) {


### PR DESCRIPTION
1. update  openfile  interface : The number of rows in the result set cannot exceed 5000 rows