### PR TITLE
add delimiter for args param

### DIFF
--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/config/FlinkEnvConfiguration.scala
@@ -95,6 +95,8 @@ object FlinkEnvConfiguration {
   val LINKIS_FLINK_LOG4J_CHECK_ENABLE = CommonVars("linkis.flink.log4j.check.enable", true)
   val LINKIS_FLINK_LOG4J_CHECK_KEYWORDS = CommonVars("linkis.flink.log4j.check.keywords", "")
   val FLINK_APPLICATION_ARGS = CommonVars("flink.app.args", "")
+
+  val FLINK_APPLICATION_SEPARATE = CommonVars("flink.app.args.separate", " ")
   val FLINK_APPLICATION_MAIN_CLASS = CommonVars("flink.app.main.class", "")
   val FLINK_APPLICATION_MAIN_CLASS_JAR = CommonVars("flink.app.main.class.jar", "")
   val FLINK_APPLICATION_CLASSPATH = CommonVars("flink.app.user.class.path", "")

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkJarOnceExecutor.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkJarOnceExecutor.scala
@@ -57,8 +57,13 @@ class FlinkJarOnceExecutor(
       options: Map[String, String]
   ): Unit = {
     val args = FLINK_APPLICATION_ARGS.getValue(options)
-    val programArguments =
-      if (StringUtils.isNotEmpty(args)) args.split(" ") else Array.empty[String]
+    val programArguments = {
+      if (StringUtils.isNotEmpty(args)) {
+        val delimiter =
+          Option(FLINK_APPLICATION_SEPARATE.getValue(options)).filter(_.nonEmpty).getOrElse(" ")
+        args.split(delimiter)
+      } else Array.empty[String]
+    }
     val mainClass = FLINK_APPLICATION_MAIN_CLASS.getValue(options)
     logger.info(s"Ready to submit flink application, mainClass: $mainClass, args: $args.")
     if (LINKIS_FLINK_LOG4J_CHECK_ENABLE.getHotValue()) {


### PR DESCRIPTION
After successfully publishing a job, we found that the args parameter was displayed correctly in streamis, but when submitting to flink, the args parameter was saperaterd with space, so we user a delimiter other than space to saperate the args param.

支持args参数中含有空格。