### PR TITLE
feat: add multiple result set support

### DIFF
--- a/linkis-computation-governance/linkis-jdbc-driver/src/main/java/org/apache/linkis/ujes/jdbc/UJESSQLDriver.java
+++ b/linkis-computation-governance/linkis-jdbc-driver/src/main/java/org/apache/linkis/ujes/jdbc/UJESSQLDriver.java
@@ -50,6 +50,7 @@ public class UJESSQLDriver extends UJESSQLDriverMain implements Driver {
   static String PASSWORD = "password";
   static boolean TABLEAU_SERVER = false;
   static String FIXED_SESSION = "fixedSession";
+  static String ENABLE_MULTI_RESULT = "enableMultiResult";
 
   static String USE_SSL = "useSSL";
   static String VERSION = "version";

--- a/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/LinkisSQLStatement.scala
+++ b/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/LinkisSQLStatement.scala
@@ -241,22 +241,22 @@ class LinkisSQLStatement(private[jdbc] val ujesSQLConnection: LinkisSQLConnectio
       this.resultSet.getMetaData
       val nextResultSet = this.resultSet.getNextResultSet
       current match {
-        case 1 =>
+        case Statement.CLOSE_CURRENT_RESULT =>
           // 1 - CLOSE CURRENT RESULT SET
           this.resultSet.close()
           this.resultSet.clearNextResultSet
-        case 2 =>
+        case Statement.KEEP_CURRENT_RESULT =>
           // 2 - KEEP CURRENT RESULT SET
           this.openedResultSets.add(this.resultSet)
           this.resultSet.clearNextResultSet
-        case 3 =>
+        case Statement.CLOSE_ALL_RESULTS =>
           // 3 - CLOSE ALL RESULT SET
           this.openedResultSets.add(this.resultSet)
           closeAllOpenedResultSet()
         case _ =>
           throw new LinkisSQLException(
             LinkisSQLErrorCode.NOSUPPORT_STATEMENT,
-            "getMoreResults with current not in 1,2,3 is not supported"
+            "getMoreResults with current not in 1,2,3 is not supported, see Statement.getMoreResults"
           )
       }
       this.resultSet = nextResultSet

--- a/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/LinkisSQLStatement.scala
+++ b/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/LinkisSQLStatement.scala
@@ -37,6 +37,10 @@ class LinkisSQLStatement(private[jdbc] val ujesSQLConnection: LinkisSQLConnectio
     with Logging {
 
   private var jobExecuteResult: JobExecuteResult = _
+
+  private val openedResultSets: util.ArrayList[UJESSQLResultSet] =
+    new util.ArrayList[UJESSQLResultSet]()
+
   private var resultSet: UJESSQLResultSet = _
   private var closed = false
   private var maxRows: Int = 0
@@ -190,7 +194,7 @@ class LinkisSQLStatement(private[jdbc] val ujesSQLConnection: LinkisSQLConnectio
 
   override def getUpdateCount: Int = throwWhenClosed(-1)
 
-  override def getMoreResults: Boolean = false
+  override def getMoreResults: Boolean = getMoreResults(Statement.CLOSE_CURRENT_RESULT)
 
   override def setFetchDirection(direction: Int): Unit =
     throwWhenClosed(if (direction != ResultSet.FETCH_FORWARD) {
@@ -230,7 +234,45 @@ class LinkisSQLStatement(private[jdbc] val ujesSQLConnection: LinkisSQLConnectio
 
   override def getConnection: Connection = throwWhenClosed(ujesSQLConnection)
 
-  override def getMoreResults(current: Int): Boolean = false
+  override def getMoreResults(current: Int): Boolean = {
+    if (this.resultSet == null) {
+      false
+    } else {
+      this.resultSet.getMetaData
+      val nextResultSet = this.resultSet.getNextResultSet
+      current match {
+        case 1 =>
+          // 1 - CLOSE CURRENT RESULT SET
+          this.resultSet.close()
+          this.resultSet.clearNextResultSet
+        case 2 =>
+          // 2 - KEEP CURRENT RESULT SET
+          this.openedResultSets.add(this.resultSet)
+          this.resultSet.clearNextResultSet
+        case 3 =>
+          // 3 - CLOSE ALL RESULT SET
+          this.openedResultSets.add(this.resultSet)
+          closeAllOpenedResultSet()
+        case _ =>
+          throw new LinkisSQLException(
+            LinkisSQLErrorCode.NOSUPPORT_STATEMENT,
+            "getMoreResults with current not in 1,2,3 is not supported"
+          )
+      }
+      this.resultSet = nextResultSet
+      this.resultSet != null
+    }
+  }
+
+  private def closeAllOpenedResultSet(): Any = {
+    val iterator = this.openedResultSets.iterator()
+    while (iterator.hasNext) {
+      val set = iterator.next()
+      if (!set.isClosed) {
+        set.close()
+      }
+    }
+  }
 
   override def getGeneratedKeys: ResultSet = throw new LinkisSQLException(
     LinkisSQLErrorCode.NOSUPPORT_STATEMENT,
@@ -302,6 +344,7 @@ class LinkisSQLStatement(private[jdbc] val ujesSQLConnection: LinkisSQLConnectio
 
   /**
    * log[0] error log[1] warn log[2] info log[3] all (info + warn + error)
+   *
    * @return
    */
   def getAllLog(): Array[String] = {
@@ -316,6 +359,7 @@ class LinkisSQLStatement(private[jdbc] val ujesSQLConnection: LinkisSQLConnectio
 
   /**
    * log[0] error log[1] warn log[2] info log[3] all (info + warn + error)
+   *
    * @return
    */
   def getIncrementalLog(): util.List[String] = {

--- a/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/UJESSQLDriverMain.scala
+++ b/linkis-computation-governance/linkis-jdbc-driver/src/main/scala/org/apache/linkis/ujes/jdbc/UJESSQLDriverMain.scala
@@ -78,6 +78,9 @@ class UJESSQLDriverMain extends Driver with Logging {
             case Array(USE_SSL, value) =>
               props.setProperty(USE_SSL, value)
               false
+            case Array(ENABLE_MULTI_RESULT, value) =>
+              props.setProperty(ENABLE_MULTI_RESULT, value)
+              false
             case Array(key, _) =>
               if (StringUtils.isBlank(key)) {
                 throw new LinkisSQLException(
@@ -141,6 +144,7 @@ object UJESSQLDriverMain {
   val PASSWORD = UJESSQLDriver.PASSWORD
   val TABLEAU_SERVER = UJESSQLDriver.TABLEAU_SERVER
   val FIXED_SESSION = UJESSQLDriver.FIXED_SESSION
+  val ENABLE_MULTI_RESULT = UJESSQLDriver.ENABLE_MULTI_RESULT
 
   val USE_SSL = UJESSQLDriver.USE_SSL
 

--- a/linkis-computation-governance/linkis-jdbc-driver/src/test/java/org/apache/linkis/ujes/jdbc/UJESSQLResultSetTest.java
+++ b/linkis-computation-governance/linkis-jdbc-driver/src/test/java/org/apache/linkis/ujes/jdbc/UJESSQLResultSetTest.java
@@ -17,7 +17,14 @@
 
 package org.apache.linkis.ujes.jdbc;
 
+import org.apache.linkis.ujes.client.UJESClient;
+import org.apache.linkis.ujes.client.request.ResultSetAction;
+import org.apache.linkis.ujes.client.response.ResultSetResult;
+
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +32,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 
 /*
  * Notice:
@@ -136,5 +147,99 @@ public class UJESSQLResultSetTest {
       }
       Assertions.assertTrue(resultSet.isAfterLast());
     }
+  }
+
+  /** single query result with no multiple result set check point 1: nextResultSet is null */
+  @Test
+  public void singleQueryWithNoMoreResultSet() {
+    Properties t = new Properties();
+    t.put("user", "hiveUser");
+    UJESClient ujesClient = Mockito.mock(UJESClient.class);
+    Mockito.when(ujesClient.resultSet(any())).thenReturn(new ResultSetResult());
+
+    LinkisSQLConnection linkisSQLConnection = new LinkisSQLConnection(ujesClient, t);
+
+    UJESSQLResultSet ujessqlResultSet =
+        new UJESSQLResultSet(
+            new String[] {"path1"}, new LinkisSQLStatement(linkisSQLConnection), 0, 0);
+
+    ujessqlResultSet.next();
+
+    assertNull(ujessqlResultSet.getNextResultSet());
+  }
+
+  /**
+   * multiple result set with multi result switch is Y check point 1: queryResult has two path,
+   * return first path. check point 2: the second result set returned check point 3: the third
+   * result set is null
+   */
+  @Test
+  public void nultiQueryWithMoreResultSet() {
+    Properties t = new Properties();
+    t.put("user", "hiveUser");
+    t.put(UJESSQLDriverMain.ENABLE_MULTI_RESULT(), "Y");
+    UJESClient ujesClient = Mockito.mock(UJESClient.class);
+    List<String> pathList = new ArrayList<>();
+    Mockito.when(ujesClient.resultSet(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              ResultSetAction argument = invocationOnMock.getArgument(0);
+              String path = (String) argument.getParameters().get("path");
+              if (pathList.isEmpty()) {
+                assertEquals("path1", path);
+              }
+              pathList.add(path);
+
+              return new ResultSetResult();
+            });
+    LinkisSQLConnection linkisSQLConnection = new LinkisSQLConnection(ujesClient, t);
+
+    UJESSQLResultSet ujessqlResultSet =
+        new UJESSQLResultSet(
+            new String[] {"path1", "path2"}, new LinkisSQLStatement(linkisSQLConnection), 0, 0);
+
+    // 查询
+    ujessqlResultSet.next();
+
+    // 存在下一个结果集
+    UJESSQLResultSet nextResultSet = ujessqlResultSet.getNextResultSet();
+    assertNotNull(nextResultSet);
+    nextResultSet.next();
+
+    // 不存在第三个结果集
+    assertNull(nextResultSet.getNextResultSet());
+  }
+
+  /**
+   * multiple result set with multi result switch not Y check point 1: queryResult has two path,
+   * return last path. check point 2: the next result set is null
+   */
+  @Test
+  public void nultiQueryWithNoMoreResultSet() {
+    Properties t = new Properties();
+    t.put("user", "hiveUser");
+    UJESClient ujesClient = Mockito.mock(UJESClient.class);
+    Mockito.when(ujesClient.resultSet(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              ResultSetAction argument = invocationOnMock.getArgument(0);
+              String path = (String) argument.getParameters().get("path");
+              assertEquals("path4", path);
+
+              return new ResultSetResult();
+            });
+
+    LinkisSQLConnection linkisSQLConnection = new LinkisSQLConnection(ujesClient, t);
+
+    UJESSQLResultSet ujessqlResultSet =
+        new UJESSQLResultSet(
+            new String[] {"path1", "path2", "path3", "path4"}, new LinkisSQLStatement(linkisSQLConnection), 0, 0);
+
+    // 查询
+    ujessqlResultSet.next();
+
+    // 即使查询有多个结果集，也不会产生多个结果集返回
+    UJESSQLResultSet nextResultSet = ujessqlResultSet.getNextResultSet();
+    assertNull(nextResultSet);
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

add multiple result set support

### Brief change log

- Statement.getMoreResults feature, add multiple result set support 

add url params: enableMultiResult = Y to open this feature. 

For example: jdbc:linkis://hostname:port/xxxx?EngineType=hive&limit=false&enableMultiResult=Y



