### PR TITLE
[1.9.0]Add department level result set restriction configuration and inspection

### DIFF
--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
@@ -68,7 +68,7 @@ object Configuration extends Logging {
   val JOB_HISTORY_DEPARTMENT_ADMIN = CommonVars("wds.linkis.jobhistory.department.admin", "hadoop")
 
   val JOB_RESULT_DEPARTMENT_LIMIT =
-    CommonVars("linkis.jobhistory.result.limit.department", "960000")
+    CommonVars("linkis.jobhistory.result.limit.department", "")
 
   // Only the specified token has permission to call some api
   val GOVERNANCE_STATION_ADMIN_TOKEN_STARTWITH = "ADMIN-"

--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
@@ -67,6 +67,9 @@ object Configuration extends Logging {
 
   val JOB_HISTORY_DEPARTMENT_ADMIN = CommonVars("wds.linkis.jobhistory.department.admin", "hadoop")
 
+  val JOB_RESULT_DEPARTMENT_LIMIT =
+    CommonVars("linkis.jobhistory.result.limit.department", "960000")
+
   // Only the specified token has permission to call some api
   val GOVERNANCE_STATION_ADMIN_TOKEN_STARTWITH = "ADMIN-"
 
@@ -157,6 +160,11 @@ object Configuration extends Logging {
         Configuration.GLOBAL_CONF_CHN_EN_NAME =>
       GLOBAL_CONF_SYMBOL
     case _ => creator
+  }
+
+  def canResultSetByDepartment(departmentId: String): Boolean = {
+    val jobResultLimit = JOB_RESULT_DEPARTMENT_LIMIT.getHotValue.split(",")
+    !jobResultLimit.exists(departmentId.equalsIgnoreCase)
   }
 
 }

--- a/linkis-public-enhancements/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
+++ b/linkis-public-enhancements/linkis-jobhistory/src/main/java/org/apache/linkis/jobhistory/restful/api/QueryRestfulApi.java
@@ -85,10 +85,12 @@ public class QueryRestfulApi {
   @RequestMapping(path = "/governanceStationAdmin", method = RequestMethod.GET)
   public Message governanceStationAdmin(HttpServletRequest req) {
     String username = ModuleUserUtils.getOperationUser(req, "governanceStationAdmin");
+    String departmentId = JobhistoryUtils.getDepartmentByuser(username);
     return Message.ok()
         .data("admin", Configuration.isAdmin(username))
         .data("historyAdmin", Configuration.isJobHistoryAdmin(username))
         .data("deptAdmin", Configuration.isDepartmentAdmin(username))
+        .data("canResultSet", Configuration.canResultSetByDepartment(departmentId))
         .data("errorMsgTip", Configuration.ERROR_MSG_TIP().getValue());
   }
 


### PR DESCRIPTION
-Add the JOB_RESILT_dePARTMENTLIMIT variable in configuration.scala to configure department result set restrictions - implement the canResultSetByDepartment method, and determine whether there is result set permission based on the department ID
-Call canResultSetByDepartment method in QueryResultApi.java to add the result to the API response