### PR TITLE
fix(web): 显示引擎日志的时候才显示UDF日志

### DIFF
--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -136,9 +136,9 @@ export default {
     let taskID = this.$route.query.taskID
     await this.initHistory(taskID);
     if(engineInstance && isAdminShowEngineLog) {
-      this.hasEngine = (!!this.jobhistoryTask.ticketId && !!this.jobhistoryTask.ecmInstance && !!this.jobhistoryTask.engineInstance);
+      this.hasEngine = (!!this.jobhistoryTask.ticketId && !!this.jobhistoryTask.ecmInstance && !!this.jobhistoryTask.engineInstance && !!this.jobhistoryTask.engineLogPath);
+      this.showUDF = this.hasEngine && ['spark', 'hive'].includes(this.jobhistoryTask?.engineType || '')
     }
-    this.showUDF = ['spark', 'hive'].includes(this.jobhistoryTask?.engineType || '')
     this.tabs = [
       { name: 'log', label: 'message.linkis.log' },
       { name: 'code', label: 'message.linkis.executionCode' },

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -20,8 +20,8 @@
 <template>
   <div class="global-history">
     <Tabs v-model="tabName" @on-click="onClickTabs">
-      <TabPane 
-        v-for="tab in tabs" 
+      <TabPane
+        v-for="tab in tabs"
         :key="tab.name"
         :name="tab.name"
         :label="$t(tab.label)">
@@ -50,7 +50,7 @@
     />
     <ViewLog ref="logPanel" :inHistory="true" v-show="tabName === 'engineLog' && hasEngine" @back="showviewlog = false" />
     <logWithPage ref="udfLog" logType="udfLog" v-show="tabName === 'udfLog' && showUDF && hasEngine" />
-    
+
     <term ref="termRef" v-if="tabName === 'terminal'" :logs="termLogs" :script-view-state="scriptViewState" :loading="termLogLoading" />
   </div>
 </template>
@@ -130,7 +130,7 @@ export default {
   async created() {
     this.hasResultData = false
     let engineInstance = this.$route.query.engineInstance
-    
+
     const engineLogOnlyAdminEnable = storage.get('engineLogOnlyAdminEnable')
     // 仅管理员可以查看引擎日志
     const isAdminShowEngineLog = !engineLogOnlyAdminEnable || (engineLogOnlyAdminEnable && (storage.get('isLogAdmin') || storage.get('isLogHistoryAdmin') || storage.get('isLogDeptAdmin')))
@@ -193,12 +193,12 @@ export default {
             this.tabName = this.preName;
           }, 0);
           window.open(`http://${window.location.host}/#/results?parentPath=${this.jobhistoryTask.resultLocation}&taskId=${this.$route.query.taskID}&fileName=example.${this.jobhistoryTask.runType}`, '_blank')
-          
+
           return;
         } catch (error) {
           window.console.error(error)
         }
-        
+
       }
       this.tabName = name
       this.preName = name
@@ -218,11 +218,11 @@ export default {
         if(this.param) {
           this.$refs.logPanel.getLogs(0, {
             applicationName: "linkis-cg-engineconn",
-            emInstance: this.param?.ecmInstance || '',
-            instance: this.param?.serviceInstance || '',
+            emInstance: this.jobhistoryTask?.ecmInstance || '',
+            instance: this.jobhistoryTask?.engineInstance || '',
             ticketId: this.param?.ticketId || '',
             engineType: this.param?.engineType || '',
-            logDirSuffix: this.param?.logDirSuffix || '',
+            logDirSuffix: this.jobhistoryTask?.engineLogPath || '',
           })
         }
 
@@ -230,11 +230,11 @@ export default {
         if(this.param) {
           this.$refs.udfLog.getLogs(0, {
             applicationName: "linkis-cg-engineconn",
-            emInstance: this.param?.ecmInstance || '',
-            instance: this.param?.serviceInstance || '',
+            emInstance: this.jobhistoryTask?.ecmInstance || '',
+            instance: this.jobhistoryTask?.engineInstance || '',
             ticketId: this.param?.ticketId || '',
             engineType: this.param?.engineType || '',
-            logDirSuffix: this.param?.logDirSuffix || '',
+            logDirSuffix: this.jobhistoryTask?.udfLogPath || '',
           })
         }
 
@@ -256,15 +256,15 @@ export default {
             window.console.error(err);
             this.termLogs = '';
           }
-          
+
         }
-        
+
       } else {
         this.$nextTick(() => {
           this.$refs.logRef.fold();
           this.foldFlag = true;
         })
-        
+
       }
     },
     changeResultSet(data, cb) {
@@ -519,7 +519,7 @@ export default {
           return
         }
         await this.getLogs(jobhistory);
-        
+
         this.isLoading = false
       } catch (errorMsg) {
         window.console.error(errorMsg)

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -119,7 +119,6 @@ export default {
       isAdminModel: false,
       jobhistoryTask: null,
       hasEngine: false,
-      param: {},
       yarnAddress: '',
       logTimer: null,
       preName: 'log',
@@ -134,20 +133,12 @@ export default {
     const engineLogOnlyAdminEnable = storage.get('engineLogOnlyAdminEnable')
     // 仅管理员可以查看引擎日志
     const isAdminShowEngineLog = !engineLogOnlyAdminEnable || (engineLogOnlyAdminEnable && (storage.get('isLogAdmin') || storage.get('isLogHistoryAdmin') || storage.get('isLogDeptAdmin')))
-
+    let taskID = this.$route.query.taskID
+    await this.initHistory(taskID);
     if(engineInstance && isAdminShowEngineLog) {
-      let url = '/linkisManager/ecinfo/ecrHistoryList?';
-      const endDate = new Date();
-      const startDate = new Date();
-      startDate.setMonth(startDate.getMonth() - 3);
-      url += `instance=${engineInstance}&startDate=${this.formatDate(startDate)}&endDate=${this.formatDate(endDate)}`;
-      const res = await api.fetch(url,'get')
-      const param = res.engineList[0]
-      this.param = param;
-      this.hasEngine = !!param;
-
+      this.hasEngine = (!!this.jobhistoryTask.ticketId && !!this.jobhistoryTask.ecmInstance && !!this.jobhistoryTask.engineInstance);
     }
-    this.showUDF = ['spark', 'hive'].includes(this.param?.engineType || '')
+    this.showUDF = ['spark', 'hive'].includes(this.jobhistoryTask?.engineType || '')
     this.tabs = [
       { name: 'log', label: 'message.linkis.log' },
       { name: 'code', label: 'message.linkis.executionCode' },
@@ -170,8 +161,6 @@ export default {
     }
   },
   async mounted() {
-    let taskID = this.$route.query.taskID
-    await this.initHistory(taskID);
     const node = document.getElementsByClassName('global-history')[0];
     this.scriptViewState.bottomContentHeight = node.clientHeight - 85;
   },
@@ -215,26 +204,26 @@ export default {
           })
         }
       } else if(name === 'engineLog') {
-        if(this.param) {
+        if(this.jobhistoryTask) {
           this.$refs.logPanel.getLogs(0, {
             applicationName: "linkis-cg-engineconn",
-            emInstance: this.jobhistoryTask?.ecmInstance || '',
-            instance: this.jobhistoryTask?.engineInstance || '',
-            ticketId: this.param?.ticketId || '',
-            engineType: this.param?.engineType || '',
-            logDirSuffix: this.jobhistoryTask?.engineLogPath || '',
+            emInstance: this.jobhistoryTask.ecmInstance || '',
+            instance: this.jobhistoryTask.engineInstance || '',
+            ticketId: this.jobhistoryTask.ticketId || '',
+            engineType: this.jobhistoryTask.engineType || '',
+            logDirSuffix: this.jobhistoryTask.engineLogPath || '',
           })
         }
 
       } else if(name === 'udfLog') {
-        if(this.param) {
+        if(this.jobhistoryTask) {
           this.$refs.udfLog.getLogs(0, {
             applicationName: "linkis-cg-engineconn",
-            emInstance: this.jobhistoryTask?.ecmInstance || '',
-            instance: this.jobhistoryTask?.engineInstance || '',
-            ticketId: this.param?.ticketId || '',
-            engineType: this.param?.engineType || '',
-            logDirSuffix: this.jobhistoryTask?.udfLogPath || '',
+            emInstance: this.jobhistoryTask.ecmInstance || '',
+            instance: this.jobhistoryTask.engineInstance || '',
+            ticketId: this.jobhistoryTask.ticketId || '',
+            engineType: this.jobhistoryTask.engineType || '',
+            logDirSuffix: this.jobhistoryTask.udfLogPath || '',
           })
         }
 

--- a/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
+++ b/linkis-web/src/apps/linkis/module/globalHistoryManagement/viewHistory.vue
@@ -223,7 +223,7 @@ export default {
             instance: this.jobhistoryTask.engineInstance || '',
             ticketId: this.jobhistoryTask.ticketId || '',
             engineType: this.jobhistoryTask.engineType || '',
-            logDirSuffix: this.jobhistoryTask.udfLogPath || '',
+            logDirSuffix: this.jobhistoryTask.engineLogPath || '',
           })
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

显示引擎日志的时候才显示UDF日志

### Related issues/PRs


### Brief change log

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
