### PR TITLE
Merge linkis-extensions from WDS master

### DIFF
--- a/linkis-extensions/linkis-et-monitor/pom.xml
+++ b/linkis-extensions/linkis-et-monitor/pom.xml
@@ -82,7 +82,36 @@
     <dependency>
       <groupId>de.codecentric</groupId>
       <artifactId>spring-boot-admin-starter-server</artifactId>
-      <version>2.7.16</version>
+      <version>${spring.boot.admin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.projectreactor.netty</groupId>
+          <artifactId>reactor-netty-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.thymeleaf</groupId>
+          <artifactId>thymeleaf</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.thymeleaf</groupId>
+          <artifactId>thymeleaf-spring5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.thymeleaf</groupId>
+      <artifactId>thymeleaf</artifactId>
+      <version>3.1.2.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.thymeleaf</groupId>
+      <artifactId>thymeleaf-spring5</artifactId>
+      <version>3.1.2.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty-http</artifactId>
+      <version>${reactor-netty-http.version}</version>
     </dependency>
 
     <dependency>

--- a/linkis-extensions/linkis-et-monitor/src/main/java/org/apache/linkis/monitor/config/ApplicationConfiguration.java
+++ b/linkis-extensions/linkis-et-monitor/src/main/java/org/apache/linkis/monitor/config/ApplicationConfiguration.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import de.codecentric.boot.admin.server.utils.jackson.AdminServerModule;
 
 @Configuration
 class ApplicationConfiguration implements WebMvcConfigurer {
@@ -35,6 +36,7 @@ class ApplicationConfiguration implements WebMvcConfigurer {
   @Primary
   public ObjectMapper jsonMapper() {
     ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new AdminServerModule(new String[] {".*password$"}));
     mapper.registerModule(new JavaTimeModule());
     return mapper;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,8 @@
     <spring-cloud.version>2021.0.8</spring-cloud.version>
     <spring-cloud-alibaba.version>2021.0.6.0</spring-cloud-alibaba.version>
     <spring-cloud-common.version>3.1.7</spring-cloud-common.version>
+    <spring.boot.admin.version>2.7.16</spring.boot.admin.version>
+    <reactor-netty-http.version>1.0.39</reactor-netty-http.version>
     <azure.blob.bom>1.2.30</azure.blob.bom>
 
     <!-- platform encoding override -->


### PR DESCRIPTION
## Changes

### Dependency Management Optimization
- Add version properties in root pom.xml for better dependency management
  - spring.boot.admin.version: 2.7.16
  - reactor-netty-http.version: 1.0.39
- Optimize linkis-et-monitor/pom.xml dependency configuration
  - Use property variables instead of hardcoded versions
  - Add dependency exclusions to resolve conflicts
  - Explicitly declare thymeleaf and reactor-netty-http dependencies

### Security Enhancement
- Add password masking feature in ApplicationConfiguration.java
  - Register AdminServerModule to automatically mask password fields in JSON output
  - Improve security by preventing sensitive information exposure

### Decisions Made
- ✅ Adopted: Dependency management optimization (from WDS)
- ✅ Adopted: Password masking security feature (from WDS)
- ❌ Not adopted: Code deletions and refactoring (keep Apache version for stability)
- ❌ Not adopted: StarRocks monitoring feature deletion (keep all features)
- ❌ Not adopted: Copyright header changes (maintain Apache license format)

## 合并变更说明

### 依赖管理优化
- 在根 pom.xml 中添加版本属性以优化依赖管理
  - spring.boot.admin.version: 2.7.16
  - reactor-netty-http.version: 1.0.39
- 优化 linkis-et-monitor/pom.xml 依赖配置
  - 使用属性变量替代硬编码版本
  - 添加依赖排除以解决冲突
  - 显式声明 thymeleaf 和 reactor-netty-http 依赖

### 安全功能增强
- 在 ApplicationConfiguration.java 中添加密码脱敏功能
  - 注册 AdminServerModule 自动屏蔽 JSON 输出中的密码字段
  - 提升安全性，防止敏感信息泄露

### 合并决策
- ✅ 采纳：依赖管理优化（来自 WDS）
- ✅ 采纳：密码脱敏安全功能（来自 WDS）
- ❌ 未采纳：代码删除和重构（保持 Apache 版本稳定性）
- ❌ 未采纳：StarRocks 监控功能删除（保留所有功能）
- ❌ 未采纳：版权声明变更（维持 Apache 许可格式）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

EngineConn-Core defines the the abstractions and interfaces of the EngineConn core functions.
The Engine Service in Linkis 0.x is refactored, EngineConn will handle the engine connection 
and session management.

### Related issues/PRs

Related issues: close #590 close #591
Related pr:#591


### Brief change log

- Define the core abstraction and interfaces of the EngineConn Factory;
- Define the core abstraction and interfaces of Executor Manager.


### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.



<!--

Note

1. Mark the PR title as `[WIP] title` until it's ready to be reviewed.
   如果PR还未准备好被review，请在标题上添加[WIP]标识(WIP work in progress)

2. Always add/update tests for any changes unless you have a good reason.
   除非您有充分的理由，否则任何修改都需要添加/更新测试
   
3. Always update the documentation to reflect the changes made in the PR.
   始终更新文档以反映 PR 中所做的更改  
   
4. After the PR is submitted, please pay attention to the execution result of git action check. 
   If there is any failure, please adjust it in time
   PR提交后，请关注git action check 执行结果，关键的check失败时，请及时修正
   
5. Before the pr is merged, if the commit is missing, you can continue to commit the code
    在未合并前，如果提交有遗漏，您可以继续提交代码 

6. After you submit PR, you can add assistant WeChat, the WeChat QR code is 
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png 
   您提交pr后，可以添加助手微信，微信二维码为
   https://user-images.githubusercontent.com/7869972/176336986-d6b9be8f-d1d3-45f1-aa45-8e6adf5dd244.png

-->
