### PR TITLE
[Datasource][datasource-manager][Backend] Add ability to get published data source by type and proxy user

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE_CN.md
+++ b/.github/PULL_REQUEST_TEMPLATE_CN.md
@@ -29,19 +29,19 @@ Happy contributing!
 
 ### What is the purpose of the change
 
-<!-- 用英文简要描述变更目的，1-2 句话即可 -->
+<!-- Briefly describe the change purpose in 1-2 sentences -->
 
 
 ### Related issues/PRs
 
-<!-- 关联的 Issue 和 PR，如 N/A 或 close #123 -->
+<!-- Related issues and PRs, e.g., N/A or close #123 -->
 
 Related issues:
 Related pr:
 
 ### Brief change log
 
-<!-- 用英文列出主要改动，使用 bullet points -->
+<!-- List the main changes using bullet points -->
 
 -
 -
@@ -59,16 +59,9 @@ Related pr:
 
 ---
 
-## Change Description (Chinese)
+### Main Changes (Detailed)
 
-### Purpose
-
-<!-- Describe the purpose in Chinese, what problem does it solve -->
-
-
-### Main Changes
-
-<!-- List the main changes in detail in Chinese -->
+<!-- List the main changes in detail -->
 
 1. **Server-side changes**:
    -

--- a/.github/PULL_REQUEST_TEMPLATE_CN.md
+++ b/.github/PULL_REQUEST_TEMPLATE_CN.md
@@ -1,23 +1,23 @@
 <!--
-PR 提交模板 - 请按照以下格式填写
+PR Submission Template - Please follow the format below
 
-标题格式：【一级模块】【二级模块】【前/后端】需求简要描述
-- 一级模块：如 Datasource、Computation-Governance、EngineConn 等
-- 二级模块：如 datasource-manager、engineconn-core 等
-- 前后端：后端 / 前端
-- 需求描述：简洁描述功能，让人通过标题就能看出功能和改动点
+Title Format: [Level-1 Module][Level-2 Module][Frontend/Backend] Brief description of the change
+- Level-1 Module: e.g., Datasource, Computation-Governance, EngineConn, etc.
+- Level-2 Module: e.g., datasource-manager, engineconn-core, etc.
+- Frontend/Backend: Backend / Frontend
+- Description: Briefly describe the feature so that the title clearly shows the function and changes
 
-示例标题：
-- 【Datasource】【datasource-manager】【后端】新增按类型和代理用户获取已发布数据源功能
-- 【Computation-Governance】【engineconn-core】【后端】修复 EngineConn 连接池泄漏问题
-- 【UI】【console】【前端】新增任务执行进度可视化功能
+Example Titles:
+- [Datasource][datasource-manager][Backend] Add ability to get published data source by type and proxy user
+- [Computation-Governance][engineconn-core][Backend] Fix EngineConn connection pool leak
+- [UI][console][Frontend] Add task execution progress visualization
 -->
 
-## PR 标题
+## PR Title
 
-<!-- 在下方填写，格式：【一级模块】【二级模块】【前/后端】需求简要描述 -->
+<!-- Fill in below, format: [Level-1 Module][Level-2 Module][Frontend/Backend] Brief description -->
 
-【】【】【】
+[][][]
 
 ---
 
@@ -59,31 +59,31 @@ Related pr:
 
 ---
 
-## 变更说明（中文）
+## Change Description (Chinese)
 
-### 功能目的
+### Purpose
 
-<!-- 用中文描述功能目的，解决什么问题 -->
+<!-- Describe the purpose in Chinese, what problem does it solve -->
 
 
-### 主要改动
+### Main Changes
 
-<!-- 用中文详细列出主要改动，可分点描述 -->
+<!-- List the main changes in detail in Chinese -->
 
-1. **服务端改动**：
+1. **Server-side changes**:
    -
    -
 
-2. **客户端改动**：
+2. **Client-side changes**:
    -
    -
 
-3. **其他改动**：
+3. **Other changes**:
    -
 
-### 涉及模块
+### Related Modules
 
-<!-- 列出涉及的模块 -->
+<!-- List the related modules -->
 
-- 【】
-- 【】
+- []
+- []

--- a/.github/PULL_REQUEST_TEMPLATE_CN.md
+++ b/.github/PULL_REQUEST_TEMPLATE_CN.md
@@ -1,0 +1,89 @@
+<!--
+PR 提交模板 - 请按照以下格式填写
+
+标题格式：【一级模块】【二级模块】【前/后端】需求简要描述
+- 一级模块：如 Datasource、Computation-Governance、EngineConn 等
+- 二级模块：如 datasource-manager、engineconn-core 等
+- 前后端：后端 / 前端
+- 需求描述：简洁描述功能，让人通过标题就能看出功能和改动点
+
+示例标题：
+- 【Datasource】【datasource-manager】【后端】新增按类型和代理用户获取已发布数据源功能
+- 【Computation-Governance】【engineconn-core】【后端】修复 EngineConn 连接池泄漏问题
+- 【UI】【console】【前端】新增任务执行进度可视化功能
+-->
+
+## PR 标题
+
+<!-- 在下方填写，格式：【一级模块】【二级模块】【前/后端】需求简要描述 -->
+
+【】【】【】
+
+---
+
+<!--
+Thank you for sending the PR! We appreciate you spending the time to work on these changes.
+You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
+Happy contributing!
+-->
+
+### What is the purpose of the change
+
+<!-- 用英文简要描述变更目的，1-2 句话即可 -->
+
+
+### Related issues/PRs
+
+<!-- 关联的 Issue 和 PR，如 N/A 或 close #123 -->
+
+Related issues:
+Related pr:
+
+### Brief change log
+
+<!-- 用英文列出主要改动，使用 bullet points -->
+
+-
+-
+-
+
+### Checklist
+
+- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
+- [ ] I have explained the need for this PR and the problem it solves
+- [ ] I have explained the changes or the new features added to this PR
+- [ ] I have added tests corresponding to this change
+- [ ] I have updated the documentation to reflect this change
+- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
+- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.
+
+---
+
+## 变更说明（中文）
+
+### 功能目的
+
+<!-- 用中文描述功能目的，解决什么问题 -->
+
+
+### 主要改动
+
+<!-- 用中文详细列出主要改动，可分点描述 -->
+
+1. **服务端改动**：
+   -
+   -
+
+2. **客户端改动**：
+   -
+   -
+
+3. **其他改动**：
+   -
+
+### 涉及模块
+
+<!-- 列出涉及的模块 -->
+
+- 【】
+- 【】

--- a/.github/PULL_REQUEST_TEMPLATE_CN.md
+++ b/.github/PULL_REQUEST_TEMPLATE_CN.md
@@ -47,16 +47,6 @@ Related pr:
 -
 -
 
-### Checklist
-
-- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
-- [ ] I have explained the need for this PR and the problem it solves
-- [ ] I have explained the changes or the new features added to this PR
-- [ ] I have added tests corresponding to this change
-- [ ] I have updated the documentation to reflect this change
-- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
-- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.
-
 ---
 
 ### Main Changes (Detailed)
@@ -80,3 +70,15 @@ Related pr:
 
 - []
 - []
+
+---
+
+### Checklist
+
+- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
+- [ ] I have explained the need for this PR and the problem it solves
+- [ ] I have explained the changes or the new features added to this PR
+- [ ] I have added tests corresponding to this change
+- [ ] I have updated the documentation to reflect this change
+- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
+- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/restful/DataSourceCoreRestfulApi.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/restful/DataSourceCoreRestfulApi.java
@@ -1121,6 +1121,42 @@ public class DataSourceCoreRestfulApi {
         },
         "Fail to get all types of data source[获取数据源列表失败]");
   }
+
+  @ApiOperation(
+      value = "getPublishedDataSourceByType",
+      notes = "get published data source by type and proxy user",
+      response = Message.class)
+  @ApiImplicitParams({
+    @ApiImplicitParam(name = "dataSourceType", required = true, dataType = "String"),
+    @ApiImplicitParam(name = "proxyUser", required = true, dataType = "String")
+  })
+  @RequestMapping(value = "/published/type", method = RequestMethod.GET)
+  public Message getPublishedDataSourceByType(
+      @RequestParam("dataSourceType") String dataSourceType,
+      @RequestParam("proxyUser") String proxyUser,
+      HttpServletRequest request) {
+    return RestfulApiHelper.doAndResponse(
+        () -> {
+          String userName =
+              ModuleUserUtils.getOperationUser(request, "getPublishedDataSourceByType");
+          DataSource dataSource =
+              dataSourceInfoService.getPublishedDataSourceByType(dataSourceType, proxyUser);
+          if (dataSource == null) {
+            return Message.error(
+                "No published data source found for type: "
+                    + dataSourceType
+                    + " and proxy user: "
+                    + proxyUser);
+          }
+          if (!AuthContext.hasPermission(dataSource, userName)) {
+            return Message.error("Don't have query permission for data source [没有数据源的查询权限]");
+          }
+          dataSource.setConnectParams(null);
+          dataSource.setParameter(null);
+          return Message.ok().data("info", dataSource);
+        },
+        "Fail to get published data source[获取已发布数据源信息失败]");
+  }
   /**
    * Inner method to insert data source
    *

--- a/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/service/DataSourceInfoService.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-datasource-manager/server/src/main/java/org/apache/linkis/datasourcemanager/core/service/DataSourceInfoService.java
@@ -290,4 +290,13 @@ public interface DataSourceInfoService {
    * @return
    */
   boolean existDataSourceEnv(String dataSourceEnvName);
+
+  /**
+   * Get published data source by type and proxy user
+   *
+   * @param dataSourceType data source type
+   * @param proxyUser proxy user
+   * @return data source entity
+   */
+  DataSource getPublishedDataSourceByType(String dataSourceType, String proxyUser);
 }

--- a/linkis-public-enhancements/linkis-pes-client/src/main/java/org/apache/linkis/datasource/client/errorcode/DatasourceClientErrorCodeSummary.java
+++ b/linkis-public-enhancements/linkis-pes-client/src/main/java/org/apache/linkis/datasource/client/errorcode/DatasourceClientErrorCodeSummary.java
@@ -31,6 +31,8 @@ public enum DatasourceClientErrorCodeSummary implements LinkisErrorCode {
   IP_NEEDED(31000, "ip is needed(ip为空)!"),
   PORT_NEEDED(31000, "port is needed(port为空)!"),
   OWNER_NEEDED(31000, "owner is needed(owner为空)!"),
+  DATASOURCE_TYPE_NEEDED(31000, "dataSourceType is needed(dataSourceType为空)!"),
+  PROXY_USER_NEEDED(31000, "proxyUser is needed(proxyUser为空)!"),
   DATASOURCE_NEEDED(31000, "datasourceTypeName is needed(datasourceTypeName为空)!"),
   CANNOT_SOURCE(
       31000, "Cannot encode the name of data source:{0} for request(无法对请求的数据源名称进行编码：{0})"),

--- a/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/DataSourceRemoteClient.scala
+++ b/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/DataSourceRemoteClient.scala
@@ -67,4 +67,9 @@ trait DataSourceRemoteClient extends RemoteClient {
   ): UpdateDataSourceParameterResult
 
   def getKeyDefinitionsByType(action: GetKeyTypeDatasourceAction): GetKeyTypeDatasourceResult
+
+  def getPublishedDataSourceByType(
+      action: GetPublishedDataSourceByTypeAction
+  ): GetPublishedDataSourceByTypeResult
+
 }

--- a/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/impl/LinkisDataSourceRemoteClient.scala
+++ b/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/impl/LinkisDataSourceRemoteClient.scala
@@ -151,4 +151,9 @@ class LinkisDataSourceRemoteClient(clientConfig: DWSClientConfig, clientName: St
       action: GetKeyTypeDatasourceAction
   ): GetKeyTypeDatasourceResult = execute(action).asInstanceOf[GetKeyTypeDatasourceResult]
 
+  override def getPublishedDataSourceByType(
+      action: GetPublishedDataSourceByTypeAction
+  ): GetPublishedDataSourceByTypeResult =
+    execute(action).asInstanceOf[GetPublishedDataSourceByTypeResult]
+
 }

--- a/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/request/GetPublishedDataSourceByTypeAction.scala
+++ b/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/request/GetPublishedDataSourceByTypeAction.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.request
+
+import org.apache.linkis.datasource.client.config.DatasourceClientConfig.DATA_SOURCE_SERVICE_MODULE
+import org.apache.linkis.datasource.client.errorcode.DatasourceClientErrorCodeSummary._
+import org.apache.linkis.datasource.client.exception.DataSourceClientBuilderException
+import org.apache.linkis.httpclient.request.GetAction
+
+class GetPublishedDataSourceByTypeAction extends GetAction with DataSourceAction {
+  private var dataSourceType: String = _
+  private var proxyUser: String = _
+
+  override def suffixURLs: Array[String] =
+    Array(DATA_SOURCE_SERVICE_MODULE.getValue, "published", "type")
+
+  override def setUser(user: String): Unit = this.user = user
+
+  override def getUser: String = this.user
+
+  private var user: String = _
+
+}
+
+object GetPublishedDataSourceByTypeAction {
+  def builder(): Builder = new Builder
+
+  class Builder private[GetPublishedDataSourceByTypeAction] () {
+    private var dataSourceType: String = _
+    private var proxyUser: String = _
+    private var system: String = _
+    private var user: String = _
+
+    def setUser(user: String): Builder = {
+      this.user = user
+      this
+    }
+
+    def setDataSourceType(dataSourceType: String): Builder = {
+      this.dataSourceType = dataSourceType
+      this
+    }
+
+    def setProxyUser(proxyUser: String): Builder = {
+      this.proxyUser = proxyUser
+      this
+    }
+
+    def setSystem(system: String): Builder = {
+      this.system = system
+      this
+    }
+
+    def build(): GetPublishedDataSourceByTypeAction = {
+      if (dataSourceType == null) {
+        throw new DataSourceClientBuilderException(DATASOURCE_TYPE_NEEDED.getErrorDesc)
+      }
+      if (proxyUser == null) {
+        throw new DataSourceClientBuilderException(PROXY_USER_NEEDED.getErrorDesc)
+      }
+      if (system == null) throw new DataSourceClientBuilderException(SYSTEM_NEEDED.getErrorDesc)
+      if (user == null) throw new DataSourceClientBuilderException(USER_NEEDED.getErrorDesc)
+
+      val action = new GetPublishedDataSourceByTypeAction
+      action.dataSourceType = this.dataSourceType
+      action.proxyUser = this.proxyUser
+      action.setParameter("dataSourceType", dataSourceType)
+      action.setParameter("proxyUser", proxyUser)
+      action.setParameter("system", system)
+      action.setUser(user)
+      action
+    }
+
+  }
+
+}

--- a/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/response/GetPublishedDataSourceByTypeResult.scala
+++ b/linkis-public-enhancements/linkis-pes-client/src/main/scala/org/apache/linkis/datasource/client/response/GetPublishedDataSourceByTypeResult.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.datasource.client.response
+
+import org.apache.linkis.datasourcemanager.common.domain.DataSource
+import org.apache.linkis.httpclient.dws.DWSHttpClient
+import org.apache.linkis.httpclient.dws.annotation.DWSHttpMessageResult
+import org.apache.linkis.httpclient.dws.response.DWSResult
+
+import scala.beans.BeanProperty
+
+@DWSHttpMessageResult("/api/rest_j/v\\d+/data-source-manager/published/type")
+class GetPublishedDataSourceByTypeResult extends DWSResult {
+  @BeanProperty var info: java.util.Map[String, Any] = _
+
+  def getDataSource: DataSource = {
+    val str = DWSHttpClient.jacksonJson.writeValueAsString(info)
+    DWSHttpClient.jacksonJson.readValue(str, classOf[DataSource])
+  }
+
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

Add the ability to get published data source by data source type and proxy user, enhancing the data source management query capability.

### Related issues/PRs

Related issues: N/A
Related pr: N/A

### Brief change log

- DataSourceCoreRestfulApi.java: Add `getPublishedDataSourceByType` REST API to query published data source by type and proxy user
- DataSourceInfoService.java / DataSourceInfoServiceImpl.java: Add `getPublishedDataSourceByType` service method with query logic
- GetPublishedDataSourceByTypeAction.scala: Add client request Action class
- GetPublishedDataSourceByTypeResult.scala: Add client response Result class
- LinkisDataSourceRemoteClient.scala / DataSourceRemoteClient.scala: Add `getPublishedDataSourceByType` client method
- DatasourceClientErrorCodeSummary.java: Add error codes `DATASOURCE_TYPE_NEEDED` and `PROXY_USER_NEEDED`
- quick-build.sh: Simplify build script by removing custom version parameters

---

### Main Changes (Detailed)

1. **Server-side changes**:
   - DataSourceCoreRestfulApi.java: Added new REST API endpoint `/api/rest_j/v1/data-source-manager/published/type` for querying published data source by type and proxy user
   - DataSourceInfoService.java / DataSourceInfoServiceImpl.java: Implemented `getPublishedDataSourceByType` method that filters published and non-expired data sources, returns the latest one by creation time
   - Added permission check to ensure user has query permission for the data source

2. **Client-side changes**:
   - GetPublishedDataSourceByTypeAction.scala: Added new Action class with parameter validation for dataSourceType and proxyUser
   - GetPublishedDataSourceByTypeResult.scala: Added new Result class for parsing response
   - LinkisDataSourceRemoteClient.scala / DataSourceRemoteClient.scala: Added `getPublishedDataSourceByType` client method

3. **Other changes**:
   - DatasourceClientErrorCodeSummary.java: Added error codes `DATASOURCE_TYPE_NEEDED` and `PROXY_USER_NEEDED`
   - quick-build.sh: Simplified build script by removing less used custom version parameters

### Related Modules

- [Datasource] linkis-datasource-manager
- [Datasource] linkis-pes-client

---

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/main/CONTRIBUTING.md#pull-requests).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.