### PR TITLE
[commons][module] integrate bes application server dependencies

### DIFF
--- a/linkis-commons/linkis-module/pom.xml
+++ b/linkis-commons/linkis-module/pom.xml
@@ -361,6 +361,36 @@
       <version>1.3.4</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.bes.appserver</groupId>
+      <artifactId>bes-lite-spring-boot-2.x-starter</artifactId>
+      <version>${bes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.bes.appserver</groupId>
+      <artifactId>bes-gmssl</artifactId>
+      <version>${bes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.bes.appserver</groupId>
+      <artifactId>bes-jasper</artifactId>
+      <version>${bes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.bes.appserver</groupId>
+      <artifactId>bes-jdbcra</artifactId>
+      <version>${bes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.bes.appserver</groupId>
+      <artifactId>bes-websocket</artifactId>
+      <version>${bes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.bes.appserver</groupId>
+      <artifactId>bes-websocket-support</artifactId>
+      <version>${bes.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
     <spotless-maven-plugin.version>2.24.1</spotless-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <jacoco.skip>false</jacoco.skip>
-
+    <bes.version>9.5.5.0141</bes.version>
     <!-- ==================== 28. JDK-17 测试参数 ==================== -->
     <extraJavaTestArgs>-XX:+IgnoreUnrecognizedVMOptions
       --add-opens=java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

This PR integrates BES (Baidu Enterprise Server) application server related dependencies into Linkis to support deployment on BES application server.

### Related issues/PRs

Related issues: none
Related pr:none

### Brief change log

- Add BES application server dependencies (bes-lite-spring-boot-2.x-starter, bes-gmssl, bes-jasper, bes-jdbcra, bes-websocket, bes-websocket-support)
- Update .gitignore for additional exclusions
- Optimize quick-build.sh script (reduced from 200+ lines)
- Update parent pom.xml version reference

### Checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.