### PR TITLE
[computation-governance][application-manager] optimize jdbc stack log, monitor cleanup, manager thread pool optimization

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/utils/AMUtils.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/utils/AMUtils.scala
@@ -44,10 +44,15 @@ import java.io.File
 import java.util
 
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContextExecutorService
 
 import com.google.gson.JsonObject
 
 object AMUtils extends Logging {
+
+  // 优化：线程池复用，线程数设置为5
+  private implicit val updateMetricsExecutor: ExecutionContextExecutorService =
+    Utils.newCachedExecutionContext(5, "UpdateMetrics-Thread-")
 
   lazy val GSON = BDPJettyServerHelper.gson
 
@@ -409,14 +414,15 @@ object AMUtils extends Logging {
     import scala.concurrent.Future
     import scala.util.{Failure, Success}
 
+    // 优化：使用复用的线程池，线程数设置为5
     Future {
       updateMetrics(taskId, resourceTicketId, emInstance, ecmInstance, engineLogPath, isReuse)
-    }(Utils.newCachedExecutionContext(1, "UpdateMetrics-Thread-")).onComplete {
+    }(updateMetricsExecutor).onComplete {
       case Success(_) =>
         logger.debug(s"Task: $taskId metrics update completed successfully for engine: $emInstance")
       case Failure(t) =>
         logger.warn(s"Task: $taskId metrics update failed for engine: $emInstance", t)
-    }(Utils.newCachedExecutionContext(1, "UpdateMetrics-Thread-"))
+    }(updateMetricsExecutor)
   }
 
 }

--- a/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCEngineConnExecutor.scala
@@ -18,6 +18,7 @@
 package org.apache.linkis.manager.engineplugin.jdbc.executor
 
 import org.apache.linkis.common.conf.Configuration
+import org.apache.linkis.common.log.LogUtils
 import org.apache.linkis.common.utils.{OverloadUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
 import org.apache.linkis.engineconn.computation.executor.execute.{
@@ -68,6 +69,7 @@ import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
 import org.apache.commons.collections.MapUtils
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 import org.springframework.util.CollectionUtils
 
@@ -235,6 +237,11 @@ class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
     } catch {
       case e: Throwable =>
         logger.error(s"Cannot run $code", e)
+        // 推送堆栈信息到前端
+        val errorStr = ExceptionUtils.getStackTrace(e)
+        engineExecutorContext.appendStdout(
+          LogUtils.generateERROR(s"execute code failed!: $errorStr")
+        )
         return ErrorExecuteResponse(e.getMessage, e)
     } finally {
       connectionManager.removeStatement(taskId)
@@ -374,6 +381,9 @@ class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
             val data = resultSet.getObject(i + 1) match {
               case value: Array[Byte] =>
                 new String(resultSet.getObject(i + 1).asInstanceOf[Array[Byte]])
+              case value: java.sql.Timestamp => value.toString
+              case value: java.sql.Time => value.toString
+              case value: java.sql.Date => value.toString
               case value: Any => resultSet.getString(i + 1)
               case _ => null
             }

--- a/linkis-extensions/linkis-et-monitor/src/main/java/org/apache/linkis/monitor/config/MonitorConfig.java
+++ b/linkis-extensions/linkis-et-monitor/src/main/java/org/apache/linkis/monitor/config/MonitorConfig.java
@@ -71,5 +71,5 @@ public class MonitorConfig {
               + "请关注是否任务正常，如果不正常您可以到Linkis/DSS管理台进行任务的kill，集群信息为BDAP({2})。详细解决方案见Q47：{3} ");
 
   public static final CommonVars<String> JOBHISTORY_CLEAR_DAY =
-      CommonVars.apply("linkis.monitor.jobhistory.clear.day", "90");
+      CommonVars.apply("linkis.monitor.jobhistory.clear.day", "60");
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

This PR optimizes three aspects to improve system observability and performance:
1. Enhance JDBC executor to output full exception stack traces to frontend
2. Adjust monitor cleanup scheduled task time from 90 days to 60 days
3. Optimize application manager thread pool for better resource utilization

### Related issues/PRs

Related issues: none
Related pr: none

### Brief change log

- AMUtils: Optimize thread pool by reusing a cached execution context with 5 threads instead of creating new ones
- JDBCEngineConnExecutor: Add full exception stack trace output to frontend when execution fails
- JDBCEngineConnExecutor: Handle java.sql.Timestamp, Time, and Date types correctly in result set
- MonitorConfig: Change jobhistory clear day from 90 to 60

### Checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible (If not, please discuss on the [Linkis mailing list](https://linkis.apache.org/community/how-to-subscribe) first)
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.