### PR TITLE
[fix][MGS][gateway] mask sensitive tokens in gateway authentication logs to prevent security leakage

### DIFF
--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/oauth/OAuth2Authentication.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/oauth/OAuth2Authentication.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.gateway.security.oauth
 
 import org.apache.linkis.common.exception.LinkisCommonErrorException
-import org.apache.linkis.common.utils.{Logging, Utils}
+import org.apache.linkis.common.utils.{Logging, TokenSensitiveUtils, Utils}
 import org.apache.linkis.gateway.config.GatewayConfiguration
 import org.apache.linkis.gateway.config.GatewayConfiguration._
 import org.apache.linkis.gateway.http.GatewayContext
@@ -130,7 +130,8 @@ object OAuth2Authentication extends Logging {
     if (StringUtils.isNotBlank(accessToken)) {
       val username = validateAccessToken(accessToken, host)
       logger.info(
-        s"OAuth authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, accessToken: $accessToken, username: $username."
+        s"OAuth authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, accessToken: ${TokenSensitiveUtils
+          .maskToken(accessToken)}, username: $username."
       )
 
       if (login) {
@@ -149,7 +150,8 @@ object OAuth2Authentication extends Logging {
       true
     } else {
       logger.info(
-        s"OAuth exchange fail, uri: ${gatewayContext.getRequest.getRequestURI}, code: $code, host: $host."
+        s"OAuth exchange fail, uri: ${gatewayContext.getRequest.getRequestURI}, code: ${TokenSensitiveUtils
+          .maskToken(code)}, host: $host."
       )
       SecurityFilter.filterResponse(gatewayContext, authMsg)
       false

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/token/TokenAuthentication.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/token/TokenAuthentication.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.gateway.security.token
 
-import org.apache.linkis.common.utils.{Logging, MD5Utils, Utils}
+import org.apache.linkis.common.utils.{Logging, MD5Utils, TokenSensitiveUtils, Utils}
 import org.apache.linkis.gateway.authentication.service.TokenService
 import org.apache.linkis.gateway.config.GatewayConfiguration
 import org.apache.linkis.gateway.config.GatewayConfiguration._
@@ -61,7 +61,12 @@ object TokenAuthentication extends Logging {
     var host = gatewayContext.getRequest.getRequestRealIpAddr()
     logger.info(
       String
-        .format("Use Linkis Auth : %s,User : %s,Ip : %s", encryptToken(token), tokenUser, host)
+        .format(
+          "Use Linkis Auth : %s,User : %s,Ip : %s",
+          TokenSensitiveUtils.maskToken(token),
+          tokenUser,
+          host
+        )
     )
     if (StringUtils.isBlank(token) || StringUtils.isBlank(tokenUser)) {
       val cookieTokenOpt = Option(gatewayContext.getRequest.getCookies.get(TOKEN_KEY)).map(_.head)
@@ -107,11 +112,13 @@ object TokenAuthentication extends Logging {
     })
     if (ok) {
       logger.info(
-        s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: $token, tokenUser: $tokenUser, host: $host."
+        s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: ${TokenSensitiveUtils
+          .maskToken(token)}, tokenUser: $tokenUser, host: $host."
       )
       if (login) {
         logger.info(
-          s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: $token, tokenUser: $tokenUser."
+          s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: ${TokenSensitiveUtils
+            .maskToken(token)}, tokenUser: $tokenUser."
         )
         GatewaySSOUtils.setLoginUser(gatewayContext, tokenUser)
         val msg =
@@ -130,7 +137,8 @@ object TokenAuthentication extends Logging {
       true
     } else {
       logger.info(
-        s"Token authentication fail, uri: ${gatewayContext.getRequest.getRequestURI}, token: $token, tokenUser: $tokenUser, host: $host."
+        s"Token authentication fail, uri: ${gatewayContext.getRequest.getRequestURI}, token: ${TokenSensitiveUtils
+          .maskToken(token)}, tokenUser: $tokenUser, host: $host."
       )
       SecurityFilter.filterResponse(gatewayContext, authMsg)
       false


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
Currently, sensitive authentication tokens (OAuth access tokens and authentication tokens) are logged in plain text within gateway authentication logs. This poses a security risk as tokens can be exposed in log files, monitoring systems, and debugging outputs, potentially leading to unauthorized access.

**Purpose of Change:**
To address this security vulnerability, this PR applies token masking to all authentication-related log statements in the gateway module. The TokenSensitiveUtils.maskToken() utility method is used to redact sensitive token values before they are written to logs.

**Value/Impact:**
After this change, sensitive tokens will be properly masked in all gateway authentication logs, reducing the risk of token leakage and improving the overall security posture of the system.

### Related issues/PRs

Related issues: close #1001
Related pr:none

### Brief change log

- Apply token masking in OAuth2Authentication logs for accessToken and code parameters
- Apply token masking in TokenAuthentication logs for token parameter
- Import TokenSensitiveUtils in both authentication classes

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.