### PR TITLE
[fix][EC][all-engines] mask user code in engine execution logs to prevent security leakage

### DIFF
--- a/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/CodeUtils.java
+++ b/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/CodeUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.linkis.common.utils;
 
+import org.apache.linkis.common.conf.Configuration;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -25,14 +27,10 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class CodeUtils {
 
-  /** Default maximum preview length */
-  private static final int DEFAULT_MAX_PREVIEW_LENGTH = 50;
-
   /** Default preview length for code snippet (first N characters) */
   private static final int DEFAULT_CODE_SNIPPET_LENGTH = 6;
 
-  /** Maximum lines to preview */
-  private static final int MAX_PREVIEW_LINES = 3;
+  private static final String MSG_EMPTY_CODE = "[empty code]";
 
   /**
    * Mask code for logging - only shows length and line count
@@ -41,12 +39,17 @@ public class CodeUtils {
    * @return masked code information
    */
   public static String maskCode(String code) {
+    if (!Configuration.CODE_MASK_ENABLED()) {
+      return code;
+    }
     if (StringUtils.isBlank(code)) {
-      return "[empty code]";
+      return MSG_EMPTY_CODE;
     }
     int length = code.length();
     int lines = code.split("\n", -1).length;
-    return String.format("[code length: %d, lines: %d]", length, lines);
+    return String.format(
+        "[code length: %d, lines: %d, snippet: %s]",
+        length, lines, getCodeSnippet(code, DEFAULT_CODE_SNIPPET_LENGTH));
   }
 
   /**
@@ -57,17 +60,17 @@ public class CodeUtils {
    * @return masked code information with snippet
    */
   public static String maskCode(String code, String codeType) {
+    if (!Configuration.CODE_MASK_ENABLED()) {
+      return code;
+    }
     if (StringUtils.isBlank(code)) {
-      return "[empty " + codeType + " code]";
+      return MSG_EMPTY_CODE + codeType;
     }
     int length = code.length();
     int lines = code.split("\n", -1).length;
-
-    // Get code snippet (first N characters for debugging)
-    String snippet = getCodeSnippet(code, DEFAULT_CODE_SNIPPET_LENGTH);
-
     return String.format(
-        "[%s code, length: %d, lines: %d, snippet: %s]", codeType, length, lines, snippet);
+        "[%s code, length: %d, lines: %d, snippet: %s]",
+        codeType, length, lines, getCodeSnippet(code, DEFAULT_CODE_SNIPPET_LENGTH));
   }
 
   /**
@@ -81,182 +84,11 @@ public class CodeUtils {
     if (StringUtils.isBlank(code)) {
       return "";
     }
-
     String trimmed = code.trim();
-
     // Always truncate for security, even if code is short
     if (trimmed.length() <= length) {
       return trimmed + "...";
     }
-
     return trimmed.substring(0, length) + "...";
-  }
-
-  /**
-   * Mask code for logging - shows type, length, line count, and preview
-   *
-   * @param code the code to mask
-   * @param codeType the type of code (e.g., "SQL", "Scala", "Python")
-   * @param maxPreviewLength maximum characters to preview
-   * @return masked code information
-   */
-  public static String maskCode(String code, String codeType, int maxPreviewLength) {
-    if (StringUtils.isBlank(code)) {
-      return "[empty " + codeType + " code]";
-    }
-    int length = code.length();
-    int lines = code.split("\n", -1).length;
-
-    if (maxPreviewLength <= 0) {
-      return String.format("[%s code, length: %d, lines: %d]", codeType, length, lines);
-    }
-
-    String preview = getPreview(code, maxPreviewLength);
-    return String.format(
-        "[%s code, length: %d, lines: %d, preview: %s]", codeType, length, lines, preview);
-  }
-
-  /**
-   * Get a safe preview of the code (truncated and cleaned)
-   *
-   * @param code the code to preview
-   * @param maxLength maximum length of preview
-   * @return safe preview string
-   */
-  public static String getPreview(String code, int maxLength) {
-    if (StringUtils.isBlank(code)) {
-      return "";
-    }
-
-    // Remove sensitive patterns (passwords, tokens, etc.)
-    String cleaned = removeSensitiveInfo(code);
-
-    // Truncate to max length
-    if (cleaned.length() <= maxLength) {
-      return cleaned;
-    }
-
-    return cleaned.substring(0, maxLength) + "...";
-  }
-
-  /**
-   * Remove sensitive information from code preview
-   *
-   * @param code the code to clean
-   * @return cleaned code
-   */
-  private static String removeSensitiveInfo(String code) {
-    // Remove common sensitive patterns
-    String cleaned = code;
-
-    // Remove password values
-    cleaned =
-        cleaned.replaceAll(
-            "(?i)(password|passwd|pwd)\\s*['\"]?\\s*[:=]\\s*['\"][^'\"]*['\"]", "$1='***'");
-    cleaned = cleaned.replaceAll("(?i)(password|passwd|pwd)\\s*[:=]\\s*[^\\s'\"]+", "$1=***");
-
-    // Remove token/key values
-    cleaned =
-        cleaned.replaceAll(
-            "(?i)(token|api[_-]?key|secret|access[_-]?key)\\s*['\"]?\\s*[:=]\\s*['\"][^'\"]*['\"]",
-            "$1='***'");
-    cleaned =
-        cleaned.replaceAll(
-            "(?i)(token|api[_-]?key|secret|access[_-]?key)\\s*[:=]\\s*[^\\s'\"]+", "$1=***");
-
-    // Remove connection strings (jdbc:, mysql:, postgres:, etc.)
-    cleaned =
-        cleaned.replaceAll("(?i)(jdbc:[^\\s'\"]+|mysql://[^\\s'\"]+|postgres://[^\\s'\"]+)", "***");
-
-    return cleaned;
-  }
-
-  /**
-   * Get only the first few lines of code (for preview)
-   *
-   * @param code the code to preview
-   * @param maxLines maximum lines to show
-   * @return preview string
-   */
-  public static String getLinePreview(String code, int maxLines) {
-    if (StringUtils.isBlank(code)) {
-      return "";
-    }
-
-    String[] lines = code.split("\n", -1);
-    StringBuilder preview = new StringBuilder();
-
-    for (int i = 0; i < Math.min(maxLines, lines.length); i++) {
-      if (i > 0) {
-        preview.append("\n");
-      }
-      preview.append(lines[i]);
-    }
-
-    if (lines.length > maxLines) {
-      preview.append("\n... (").append(lines.length - maxLines).append(" more lines)");
-    }
-
-    return preview.toString();
-  }
-
-  /**
-   * Get code type from file extension or code content
-   *
-   * @param code the code
-   * @param fileType file extension (e.g., ".sql", ".scala", ".py")
-   * @return detected code type
-   */
-  public static String detectCodeType(String code, String fileType) {
-    if (StringUtils.isNotBlank(fileType)) {
-      switch (fileType.toLowerCase()) {
-        case ".sql":
-          return "SQL";
-        case ".scala":
-          return "Scala";
-        case ".py":
-          return "Python";
-        case ".java":
-          return "Java";
-        case ".sh":
-        case ".bash":
-          return "Shell";
-        case "hql":
-          return "HiveQL";
-        default:
-          break;
-      }
-    }
-
-    // Try to detect from content
-    if (StringUtils.isBlank(code)) {
-      return "Unknown";
-    }
-
-    String trimmed = code.trim().toUpperCase();
-
-    if (trimmed.startsWith("SELECT")
-        || trimmed.startsWith("INSERT")
-        || trimmed.startsWith("UPDATE")
-        || trimmed.startsWith("DELETE")
-        || trimmed.startsWith("CREATE")
-        || trimmed.startsWith("ALTER")
-        || trimmed.startsWith("DROP")
-        || trimmed.startsWith("WITH")) {
-      return "SQL";
-    }
-
-    if (trimmed.contains("DEF ") || trimmed.contains("CLASS ") || trimmed.startsWith("IMPORT ")) {
-      if (code.contains("println") || code.contains("Array(")) {
-        return "Scala";
-      }
-      return "Java";
-    }
-
-    if (trimmed.startsWith("IMPORT ") || trimmed.contains("PRINT ") || trimmed.contains("DEF ")) {
-      return "Python";
-    }
-
-    return "Unknown";
   }
 }

--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
@@ -103,6 +103,8 @@ object Configuration extends Logging {
 
   val TOKEN_MASK_ENABLED: Boolean = CommonVars("linkis.log.token.mask.enable", true).getValue
 
+  val CODE_MASK_ENABLED: Boolean = CommonVars("linkis.log.code.mask.enable", true).getValue
+
   val METRICS_INCREMENTAL_UPDATE_ENABLE =
     CommonVars[Boolean]("linkis.jobhistory.metrics.incremental.update.enable", false)
 

--- a/linkis-engineconn-plugins/flink/flink-core/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkCodeOnceExecutor.scala
+++ b/linkis-engineconn-plugins/flink/flink-core/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkCodeOnceExecutor.scala
@@ -114,7 +114,7 @@ class FlinkCodeOnceExecutor(
   protected def runCode(code: String): Unit = {
     if (isClosed) return
     val trimmedCode = StringUtils.trim(code)
-    logger.info(s"$getId >> " + trimmedCode)
+    logger.info(s"$getId >> " + CodeUtils.maskCode(trimmedCode, EngineType.FLINK.toString()))
     val startTime = System.currentTimeMillis
     val callOpt = SqlCommandParser.getSqlCommandParser.parse(code.trim, true)
     if (!callOpt.isPresent) {

--- a/linkis-engineconn-plugins/flink/flink-core/src/main/scala/org/apache/linkis/engineconnplugin/flink/ql/impl/CreateTableAsSelectGrammar.scala
+++ b/linkis-engineconn-plugins/flink/flink-core/src/main/scala/org/apache/linkis/engineconnplugin/flink/ql/impl/CreateTableAsSelectGrammar.scala
@@ -17,8 +17,10 @@
 
 package org.apache.linkis.engineconnplugin.flink.ql.impl
 
+import org.apache.linkis.common.utils.CodeUtils
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.OperationUtil
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.result.ResultSet
 import org.apache.linkis.engineconnplugin.flink.context.FlinkEngineConnContext
 import org.apache.linkis.engineconnplugin.flink.ql.Grammar
@@ -41,7 +43,7 @@ class CreateTableAsSelectGrammar(context: FlinkEngineConnContext, sql: String)
    */
   override def execute(): ResultSet = sql match {
     case CreateTableAsSelectGrammar.CREATE_TABLE_AS_SELECT_GRAMMAR(_, _, tableName, _, _, select) =>
-      logger.info(s"Ready to create a table $tableName, the sql is: $select.")
+      logger.info(s"Ready to create a table $tableName, the sql is: ${CodeUtils.maskCode(select, EngineType.FLINK.toString())}.")
       val function = new java.util.function.Function[TableEnvironmentInternal, Unit] {
         override def apply(t: TableEnvironmentInternal): Unit = {
           val table = t.sqlQuery(select)

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConcurrentConnExecutor.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConcurrentConnExecutor.scala
@@ -18,12 +18,9 @@
 package org.apache.linkis.engineplugin.hive.executor
 
 import org.apache.linkis.common.exception.ErrorException
-import org.apache.linkis.common.utils.{ByteTimeUtils, Logging, Utils}
+import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
-import org.apache.linkis.engineconn.computation.executor.execute.{
-  ConcurrentComputationExecutor,
-  EngineExecutionContext
-}
+import org.apache.linkis.engineconn.computation.executor.execute.{ConcurrentComputationExecutor, EngineExecutionContext}
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.executor.entity.{ConcurrentExecutor, ResourceFetchExecutor}
 import org.apache.linkis.engineplugin.hive.conf.{Counters, HiveEngineConfiguration}
@@ -36,35 +33,21 @@ import org.apache.linkis.engineplugin.hive.exception.HiveQueryFailedException
 import org.apache.linkis.governance.common.paser.SQLCodeParser
 import org.apache.linkis.governance.common.utils.JobUtils
 import org.apache.linkis.hadoop.common.conf.HadoopConf
-import org.apache.linkis.manager.common.entity.resource.{
-  CommonNodeResource,
-  LoadInstanceResource,
-  NodeResource
-}
+import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, LoadInstanceResource, NodeResource}
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.protocol.engine.JobProgressInfo
-import org.apache.linkis.scheduler.executer.{
-  CompletedExecuteResponse,
-  ErrorExecuteResponse,
-  ExecuteResponse,
-  SuccessExecuteResponse
-}
+import org.apache.linkis.scheduler.executer.{CompletedExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 import org.apache.linkis.storage.domain.{Column, DataType}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
-
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.{FieldSchema, Schema}
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.exec.mr.HadoopJobExecHelper
-import org.apache.hadoop.hive.ql.processors.{
-  CommandProcessor,
-  CommandProcessorFactory,
-  CommandProcessorResponse
-}
+import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorFactory, CommandProcessorResponse}
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.mapred.{JobStatus, RunningJob}
 import org.apache.hadoop.security.UserGroupInformation
@@ -72,19 +55,12 @@ import org.apache.hadoop.security.UserGroupInformation
 import java.io.ByteArrayOutputStream
 import java.security.PrivilegedExceptionAction
 import java.util
-import java.util.concurrent.{
-  Callable,
-  ConcurrentHashMap,
-  LinkedBlockingQueue,
-  ThreadPoolExecutor,
-  TimeUnit
-}
-
+import java.util.concurrent.{Callable, ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.slf4j.LoggerFactory
 
 class HiveEngineConcurrentConnExecutor(
@@ -241,7 +217,7 @@ class HiveEngineConcurrentConnExecutor(
                 s"driver compile realCode : \n ${realCode} \n finished, status : ${compileRet}"
               )
               if (0 != compileRet) {
-                logger.warn(s"compile realCode : \n ${realCode} \n error status : ${compileRet}")
+                logger.warn(s"compile realCode : \n ${CodeUtils.maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
                 throw HiveQueryFailedException(
                   COMPILE_HIVE_QUERY_ERROR.getErrorCode,
                   COMPILE_HIVE_QUERY_ERROR.getErrorDesc

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
@@ -18,23 +18,17 @@
 package org.apache.linkis.engineplugin.hive.executor
 
 import org.apache.linkis.common.exception.ErrorException
-import org.apache.linkis.common.utils.{ByteTimeUtils, Logging, Utils}
+import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
-import org.apache.linkis.engineconn.computation.executor.execute.{
-  ComputationExecutor,
-  EngineExecutionContext
-}
+import org.apache.linkis.engineconn.computation.executor.execute.{ComputationExecutor, EngineExecutionContext}
 import org.apache.linkis.engineconn.computation.executor.utlis.ProgressUtils
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.executor.entity.ResourceFetchExecutor
 import org.apache.linkis.engineplugin.hive.conf.{Counters, HiveEngineConfiguration}
 import org.apache.linkis.engineplugin.hive.conf.HiveEngineConfiguration.HIVE_TAG_USER_ENABLE
 import org.apache.linkis.engineplugin.hive.cs.CSHiveHelper
-import org.apache.linkis.engineplugin.hive.errorcode.HiveErrorCodeSummary.{
-  COMPILE_HIVE_QUERY_ERROR,
-  GET_FIELD_SCHEMAS_ERROR
-}
+import org.apache.linkis.engineplugin.hive.errorcode.HiveErrorCodeSummary.{COMPILE_HIVE_QUERY_ERROR, GET_FIELD_SCHEMAS_ERROR}
 import org.apache.linkis.engineplugin.hive.exception.HiveQueryFailedException
 import org.apache.linkis.engineplugin.hive.progress.HiveProgressHelper
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants
@@ -46,15 +40,10 @@ import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.protocol.engine.JobProgressInfo
-import org.apache.linkis.scheduler.executer.{
-  ErrorExecuteResponse,
-  ExecuteResponse,
-  SuccessExecuteResponse
-}
+import org.apache.linkis.scheduler.executer.{ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 import org.apache.linkis.storage.domain.{Column, DataType}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
-
 import org.apache.commons.collections.MapUtils
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.hive.common.HiveInterruptUtils
@@ -65,24 +54,19 @@ import org.apache.hadoop.hive.ql.exec.Task.TaskState
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.exec.mr.HadoopJobExecHelper
 import org.apache.hadoop.hive.ql.exec.tez.TezJobExecHelper
-import org.apache.hadoop.hive.ql.processors.{
-  CommandProcessor,
-  CommandProcessorFactory,
-  CommandProcessorResponse
-}
+import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorFactory, CommandProcessorResponse}
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.mapred.{JobStatus, RunningJob}
 import org.apache.hadoop.security.UserGroupInformation
+import org.apache.linkis.manager.label.entity.engine.EngineType
 
 import java.io.ByteArrayOutputStream
 import java.security.PrivilegedExceptionAction
 import java.util
 import java.util.concurrent.atomic.AtomicBoolean
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-
 import org.slf4j.LoggerFactory
 
 class HiveEngineConnExecutor(
@@ -280,10 +264,10 @@ class HiveEngineConnExecutor(
             Utils.tryCatch {
               compileRet = driver.compile(realCode)
               logger.info(
-                s"driver compile realCode : \n ${realCode} \n finished, status : ${compileRet}"
+                s"driver compile realCode : \n ${CodeUtils.maskCode(realCode, EngineType.HIVE.toString())} \n finished, status : ${compileRet}"
               )
               if (0 != compileRet) {
-                logger.warn(s"compile realCode : \n ${realCode} \n error status : ${compileRet}")
+                logger.warn(s"compile realCode : \n ${CodeUtils.maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
                 throw HiveQueryFailedException(
                   COMPILE_HIVE_QUERY_ERROR.getErrorCode,
                   COMPILE_HIVE_QUERY_ERROR.getErrorDesc

--- a/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCEngineConnExecutor.scala
@@ -19,64 +19,40 @@ package org.apache.linkis.manager.engineplugin.jdbc.executor
 
 import org.apache.linkis.common.conf.Configuration
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.{OverloadUtils, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, OverloadUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
-import org.apache.linkis.engineconn.computation.executor.execute.{
-  ConcurrentComputationExecutor,
-  EngineExecutionContext
-}
+import org.apache.linkis.engineconn.computation.executor.execute.{ConcurrentComputationExecutor, EngineExecutionContext}
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.governance.common.paser.SQLCodeParser
-import org.apache.linkis.governance.common.protocol.conf.{
-  RequestQueryEngineConfig,
-  ResponseQueryConfig
-}
-import org.apache.linkis.manager.common.entity.resource.{
-  CommonNodeResource,
-  LoadResource,
-  NodeResource
-}
+import org.apache.linkis.governance.common.protocol.conf.{RequestQueryEngineConfig, ResponseQueryConfig}
+import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, LoadResource, NodeResource}
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.engineplugin.jdbc.ConnectionManager
 import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration
-import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration.{
-  NOT_SUPPORT_LIMIT_DBS,
-  SUPPORT_CONN_PARAM_EXECUTE_ENABLE
-}
+import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration.{NOT_SUPPORT_LIMIT_DBS, SUPPORT_CONN_PARAM_EXECUTE_ENABLE}
 import org.apache.linkis.manager.engineplugin.jdbc.constant.JDBCEngineConnConstant
 import org.apache.linkis.manager.engineplugin.jdbc.errorcode.JDBCErrorCodeSummary.JDBC_GET_DATASOURCEINFO_ERROR
-import org.apache.linkis.manager.engineplugin.jdbc.exception.{
-  JDBCGetDatasourceInfoException,
-  JDBCParamsIllegalException
-}
+import org.apache.linkis.manager.engineplugin.jdbc.exception.{JDBCGetDatasourceInfoException, JDBCParamsIllegalException}
 import org.apache.linkis.manager.engineplugin.jdbc.monitor.ProgressMonitor
 import org.apache.linkis.manager.label.entity.Label
-import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import org.apache.linkis.manager.label.entity.engine.{EngineType, EngineTypeLabel, UserCreatorLabel}
 import org.apache.linkis.protocol.CacheableProtocol
 import org.apache.linkis.protocol.constants.TaskConstant
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.rpc.{RPCMapCache, Sender}
-import org.apache.linkis.scheduler.executer.{
-  AliasOutputExecuteResponse,
-  ErrorExecuteResponse,
-  ExecuteResponse,
-  SuccessExecuteResponse
-}
+import org.apache.linkis.scheduler.executer.{AliasOutputExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 import org.apache.linkis.storage.domain.{Column, DataType}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
-
 import org.apache.commons.collections.MapUtils
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.springframework.util.CollectionUtils
 
 import java.sql.{Connection, ResultSet, Statement}
 import java.util
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.collection.mutable.ArrayBuffer
 
 class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
@@ -236,7 +212,7 @@ class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
       }
     } catch {
       case e: Throwable =>
-        logger.error(s"Cannot run $code", e)
+        logger.error(s"Cannot run ${CodeUtils.maskCode(code, EngineType.JDBC.toString())}", e)
         // 推送堆栈信息到前端
         val errorStr = ExceptionUtils.getStackTrace(e)
         engineExecutorContext.appendStdout(

--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.manager.engineplugin.python.executor
 
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.execute.{
   ComputationExecutor,
   EngineExecutionContext
@@ -110,7 +110,7 @@ class PythonEngineConnExecutor(id: Int, pythonSession: PythonSession, outputPrin
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.debug("newcode is " + newcode)
+    logger.debug("newcode is " + CodeUtils.maskCode(newcode, "python"))
     executeLine(engineExecutionContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelFlinkOnceCodeExecutor.scala
+++ b/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelFlinkOnceCodeExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.seatunnel.executor
 
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf.ENGINE_CONN_LOCAL_PATH_PWD_KEY
 import org.apache.linkis.engineconn.computation.executor.utlis.ComputationEngineUtils.GSON
 import org.apache.linkis.engineconn.core.EngineConnObject
@@ -84,7 +84,7 @@ class SeatunnelFlinkOnceCodeExecutor(
     logger.info("flink doSubmit args:" + params)
     future = Utils.defaultScheduler.submit(new Runnable {
       override def run(): Unit = {
-        logger.info("Try to execute codes." + code)
+        logger.info("Try to execute codes." + CodeUtils.maskCode(code, "seatunnel"))
         if (runCode(code) != 0) {
           isFailed = true
           setResponse(

--- a/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelSparkOnceCodeExecutor.scala
+++ b/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelSparkOnceCodeExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.seatunnel.executor
 
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf.ENGINE_CONN_LOCAL_PATH_PWD_KEY
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.once.executor.{
@@ -70,7 +70,7 @@ class SeatunnelSparkOnceCodeExecutor(
       .asInstanceOf[util.Map[String, String]]
     future = Utils.defaultScheduler.submit(new Runnable {
       override def run(): Unit = {
-        logger.info("Try to execute codes." + code)
+        logger.info("Try to execute codes." + CodeUtils.maskCode(code, "seatunnel"))
         if (runCode(code) != 0) {
           isFailed = true
           setResponse(

--- a/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelZetaOnceCodeExecutor.scala
+++ b/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelZetaOnceCodeExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.seatunnel.executor
 
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf.ENGINE_CONN_LOCAL_PATH_PWD_KEY
 import org.apache.linkis.engineconn.computation.executor.utlis.ComputationEngineUtils.GSON
 import org.apache.linkis.engineconn.core.EngineConnObject
@@ -67,7 +67,7 @@ class SeatunnelZetaOnceCodeExecutor(
       .asInstanceOf[util.Map[String, String]]
     future = Utils.defaultScheduler.submit(new Runnable {
       override def run(): Unit = {
-        logger.info("Try to execute codes." + code)
+        logger.info("Try to execute codes." + CodeUtils.maskCode(code, "seatunnel"))
         if (runCode(code) != 0) {
           isFailed = true
           setResponse(

--- a/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnConcurrentExecutor.scala
+++ b/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnConcurrentExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.manager.engineplugin.shell.executor
 
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.{Logging, OverloadUtils, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, Logging, OverloadUtils, Utils}
 import org.apache.linkis.engineconn.acessible.executor.listener.event.TaskLogUpdateEvent
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
 import org.apache.linkis.engineconn.computation.executor.execute.{
@@ -85,7 +85,7 @@ class ShellEngineConnConcurrentExecutor(id: Int)
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.debug("newcode is " + newcode)
+    logger.debug("newcode is " + CodeUtils.maskCode(newcode, "shell"))
     executeLine(engineExecutionContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.manager.engineplugin.shell.executor
 
-import org.apache.linkis.common.utils.{Logging, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
 import org.apache.linkis.engineconn.computation.executor.execute.{
   ComputationExecutor,
@@ -76,7 +76,7 @@ class ShellEngineConnExecutor(id: Int) extends ComputationExecutor with Logging 
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.debug("newcode is " + newcode)
+    logger.debug("newcode is " + CodeUtils.maskCode(newcode, "shell"))
     executeLine(engineExecutionContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/JdbcSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/JdbcSink.scala
@@ -18,16 +18,15 @@
 package org.apache.linkis.engineplugin.spark.datacalc.sink
 
 import org.apache.linkis.common.utils.ClassUtils.getFieldVal
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
-
 import org.apache.commons.lang3.StringUtils
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 import java.sql.{Connection, DriverManager}
-
 import scala.collection.JavaConverters._
 
 class JdbcSink extends DataCalcSink[JdbcSinkConfig] with Logging {
@@ -64,7 +63,7 @@ class JdbcSink extends DataCalcSink[JdbcSinkConfig] with Logging {
             DriverManager.getConnection(config.getUrl, config.getUser, config.getPassword)
           try {
             config.getPreQueries.asScala.foreach(query => {
-              logger.info(s"Execute pre query: $query")
+              logger.info(s"Execute pre query: ${CodeUtils.maskCode(query, EngineType.SPARK.toString())}")
               execute(conn, jdbcOptions, query)
             })
           } catch {
@@ -86,7 +85,7 @@ class JdbcSink extends DataCalcSink[JdbcSinkConfig] with Logging {
   }
 
   private def execute(conn: Connection, jdbcOptions: JDBCOptions, query: String): Unit = {
-    logger.info("Execute query: {}", query)
+    logger.info("Execute query: {}", CodeUtils.maskCode(query, EngineType.SPARK.toString()))
     val statement = conn.prepareStatement(query)
     try {
       // `queryTimeout` was added after spark2.4.0, more details please check SPARK-23856

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/transform/SqlTransform.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/transform/SqlTransform.scala
@@ -17,15 +17,15 @@
 
 package org.apache.linkis.engineplugin.spark.datacalc.transform
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcTransform
-
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 
 class SqlTransform extends DataCalcTransform[SqlTransformConfig] with Logging {
 
   override def process(spark: SparkSession, ds: Dataset[Row]): Dataset[Row] = {
-    logger.info(s"Load data from query: ${config.getSql}")
+    logger.info(s"Load data from query: ${CodeUtils.maskCode(config.getSql, EngineType.SPARK.toString())}")
     spark.sql(config.getSql)
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPostExecutionHook.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPostExecutionHook.scala
@@ -17,21 +17,19 @@
 
 package org.apache.linkis.engineplugin.spark.mdq
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
 import org.apache.linkis.engineplugin.spark.common.SparkKind
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.extension.SparkPostExecutionHook
 import org.apache.linkis.governance.common.constant.CodeConstants
 import org.apache.linkis.governance.common.constant.job.TaskInfoConstants
-import org.apache.linkis.manager.label.entity.engine.CodeLanguageLabel
+import org.apache.linkis.manager.label.entity.engine.{CodeLanguageLabel, EngineType}
 import org.apache.linkis.protocol.mdq.{DDLCompleteResponse, DDLExecuteResponse}
 import org.apache.linkis.rpc.Sender
 import org.apache.linkis.scheduler.executer.{ExecuteResponse, SuccessExecuteResponse}
 import org.apache.linkis.storage.utils.StorageUtils
-
 import org.apache.commons.lang3.StringUtils
-
 import org.springframework.stereotype.Component
 
 import javax.annotation.PostConstruct
@@ -73,10 +71,10 @@ class MDQPostExecutionHook extends SparkPostExecutionHook with Logging {
         sender.ask(DDLExecuteResponse(true, code, StorageUtils.getJvmUser)) match {
           case DDLCompleteResponse(status) =>
             if (!status) {
-              logger.warn(s"failed to execute create table :$code (执行建表失败):$code")
+              logger.warn(s"failed to execute create table :${CodeUtils.maskCode(code, EngineType.SPARK.toString())} (执行建表失败):${CodeUtils.maskCode(code, EngineType.SPARK.toString())}")
             }
         }
-      case _ => logger.warn(s"failed to execute create table:$code (执行建表失败:$code)")
+      case _ => logger.warn(s"failed to execute create table:${CodeUtils.maskCode(code, EngineType.SPARK.toString())} (执行建表失败:${CodeUtils.maskCode(code, EngineType.SPARK.toString())})")
     }
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/metadata/MetaDataInfoTool.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/metadata/MetaDataInfoTool.scala
@@ -17,9 +17,9 @@
 
 package org.apache.linkis.engineplugin.spark.metadata
 
-import org.apache.linkis.common.utils.Logging
-
-import org.apache.spark.sql.{DataFrame, Dataset, SparkLogicalPlanHelper, SQLContext}
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
+import org.apache.linkis.manager.label.entity.engine.EngineType
+import org.apache.spark.sql.{DataFrame, Dataset, SQLContext, SparkLogicalPlanHelper}
 
 /**
  * Description:
@@ -27,11 +27,11 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkLogicalPlanHelper, SQLCont
 class MetaDataInfoTool extends Logging {
 
   def getMetaDataInfo(sqlContext: SQLContext, sql: String, dataFrame: DataFrame): String = {
-    logger.info(s"begin to get sql metadata info: ${cutSql(sql)}")
+    logger.info(s"begin to get sql metadata info: ${CodeUtils.maskCode(sql, EngineType.SPARK.toString())}")
     val startTime = System.currentTimeMillis
     val inputTables =
       SparkLogicalPlanHelper.extract(sqlContext, sql, dataFrame.queryExecution, startTime)
-    logger.info(s"end to get sql metadata info: ${cutSql(sql)}, metadata is ${inputTables}")
+    logger.info(s"end to get sql metadata info: ${CodeUtils.maskCode(sql, EngineType.SPARK.toString())}, metadata is ${inputTables}")
     if (inputTables != null) inputTables.toString else ""
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
Currently, user-submitted code is logged in plain text in various engine executor logs (Spark, Hive, Flink, JDBC, Python, Shell, Seatunnel). This poses a security and privacy risk as sensitive user code can be exposed in log files, monitoring systems, and debugging outputs.

**Purpose of Change:**
To address this security vulnerability, this PR applies code masking using CodeUtils.maskCode() to all engine executor log statements that output user code. The masking ensures that only a safe portion of the code is displayed in logs while maintaining debugging utility.

**Value/Impact:**
After this change, user code will be properly masked across all supported engine executors, protecting user privacy and preventing sensitive business logic from being leaked through log files.

### Related issues/PRs

Related issues: close #999
Related pr:none

### Brief change log

- Apply code masking in Hive engine executor logs
- Apply code masking in Flink engine executor logs
- Apply code masking in Spark engine executor logs (including DataCalc and MDQ)
- Apply code masking in JDBC engine executor logs
- Apply code masking in Python engine executor logs
- Apply code masking in Shell engine executor logs
- Apply code masking in Seatunnel engine executor logs
- Import CodeUtils and EngineType in affected executor classes

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.