### PR TITLE
[chore][COM][core] upgrade scala version from 2.12.17 to 2.12.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1598,7 +1598,7 @@
         <revision>2.0.0-spark3</revision>
         <json4s.version>3.7.0-M11</json4s.version>
         <spark.version>3.4.4</spark.version>
-        <scala.version>2.12.17</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <jackson-bom.version>2.14.2</jackson-bom.version>
       </properties>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
Scala 2.12.17 is the currently used version in Linkis 2.0.0. Scala 2.12.18 is a maintenance release that includes important bug fixes and improvements over the previous version, providing better stability and compatibility.

**Purpose of Change:**
To stay current with the Scala 2.12 maintenance releases and benefit from the latest bug fixes, this PR upgrades the Scala version from 2.12.17 to 2.12.18 in the root pom.xml configuration.

**Value/Impact:**
After this change, Linkis will benefit from the stability improvements and bug fixes in Scala 2.12.18, ensuring better runtime behavior and compatibility with the Scala ecosystem.

### Related issues/PRs

Related issues: close #1005
Related pr:none

### Brief change log

- Upgrade scala.version from 2.12.17 to 2.12.18 in root pom.xml

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.