### PR TITLE
[fix][CGS] Add MDC jobId tracing for task-related logs

### DIFF
--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
@@ -541,7 +541,12 @@ class TaskExecutionServiceImpl
   override def dealRequestTaskStatus(requestTaskStatus: RequestTaskStatus): ResponseTaskStatus = {
     val task = getTaskByTaskId(requestTaskStatus.execId)
     if (null != task) {
-      ResponseTaskStatus(task.getTaskId, task.getStatus)
+      LoggerUtils.setJobIdMDC(task.getTaskId)
+      try {
+        ResponseTaskStatus(task.getTaskId, task.getStatus)
+      } finally {
+        LoggerUtils.removeJobIdMDC()
+      }
     } else {
       val msg =
         "Task null! requestTaskStatus: " + ComputationEngineUtils.GSON.toJson(requestTaskStatus)
@@ -552,18 +557,33 @@ class TaskExecutionServiceImpl
 
   @Receiver
   override def dealRequestTaskPause(requestTaskPause: RequestTaskPause): Unit = {
-    logger.info(s"Pause is Not supported for task : " + requestTaskPause.execId)
+    LoggerUtils.setJobIdMDC(requestTaskPause.execId)
+    try {
+      logger.info(s"Pause is Not supported for task : " + requestTaskPause.execId)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
   }
 
   @Receiver
   override def dealRequestTaskKill(requestTaskKill: RequestTaskKill): Unit = {
-    logger.warn(s"Requested to kill task : ${requestTaskKill.execId}")
-    killTask(requestTaskKill.execId)
+    LoggerUtils.setJobIdMDC(requestTaskKill.execId)
+    try {
+      logger.warn(s"Requested to kill task : ${requestTaskKill.execId}")
+      killTask(requestTaskKill.execId)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
   }
 
   @Receiver
   override def dealRequestTaskResume(requestTaskResume: RequestTaskResume): Unit = {
-    logger.info(s"Resume is Not support for task : " + requestTaskResume.execId)
+    LoggerUtils.setJobIdMDC(requestTaskResume.execId)
+    try {
+      logger.info(s"Resume is Not support for task : " + requestTaskResume.execId)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
   }
 
   override def onEvent(event: EngineConnSyncEvent): Unit = event match {

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceRestfulApi.java
@@ -27,6 +27,7 @@ import org.apache.linkis.entrance.utils.JobHistoryHelper;
 import org.apache.linkis.entrance.utils.RGBUtils;
 import org.apache.linkis.entrance.vo.YarnResourceWithStatusVo;
 import org.apache.linkis.governance.common.entity.job.JobRequest;
+import org.apache.linkis.governance.common.utils.LoggerUtils;
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus;
 import org.apache.linkis.protocol.constants.TaskConstant;
 import org.apache.linkis.protocol.engine.JobInstance;
@@ -118,27 +119,32 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
     Job job = entranceServer.execute(json);
     JobRequest jobReq = ((EntranceJob) job).getJobRequest();
     Long jobReqId = jobReq.getId();
-    ModuleUserUtils.getOperationUser(req, "execute task,id: " + jobReqId);
-    String execID =
-        ZuulEntranceUtils.generateExecID(
-            job.getId(),
-            Sender.getThisServiceInstance().getApplicationName(),
-            new String[] {Sender.getThisInstance()});
-    pushLog(
-        LogUtils.generateInfo(
-            "Your job is accepted,  jobID is "
-                + execID
-                + " and taskID is "
-                + jobReqId
-                + " in "
-                + Sender.getThisServiceInstance().toString()
-                + ". \n Please wait it to be scheduled(您的任务已经提交，进入排队中，如果一直没有更新日志，是任务并发达到了限制，可以在ITSM提Linkis参数修改单)"),
-        job);
-    message = Message.ok();
-    message.setMethod("/api/entrance/execute");
-    message.data("execID", execID);
-    message.data("taskID", jobReqId);
-    logger.info("End to get an an execID: {}, taskID: {}", execID, jobReqId);
+    LoggerUtils.setJobIdMDC(String.valueOf(jobReqId));
+    try {
+      ModuleUserUtils.getOperationUser(req, "execute task,id: " + jobReqId);
+      String execID =
+          ZuulEntranceUtils.generateExecID(
+              job.getId(),
+              Sender.getThisServiceInstance().getApplicationName(),
+              new String[] {Sender.getThisInstance()});
+      pushLog(
+          LogUtils.generateInfo(
+              "Your job is accepted,  jobID is "
+                  + execID
+                  + " and taskID is "
+                  + jobReqId
+                  + " in "
+                  + Sender.getThisServiceInstance().toString()
+                  + ". \n Please wait it to be scheduled(您的任务已经提交，进入排队中，如果一直没有更新日志，是任务并发达到了限制，可以在ITSM提Linkis参数修改单)"),
+          job);
+      message = Message.ok();
+      message.setMethod("/api/entrance/execute");
+      message.data("execID", execID);
+      message.data("taskID", jobReqId);
+      logger.info("End to get an an execID: {}, taskID: {}", execID, jobReqId);
+    } finally {
+      LoggerUtils.removeJobIdMDC();
+    }
     return message;
   }
 
@@ -177,27 +183,32 @@ public class EntranceRestfulApi implements EntranceRestfulRemote {
     Job job = entranceServer.execute(json);
     JobRequest jobRequest = ((EntranceJob) job).getJobRequest();
     Long jobReqId = jobRequest.getId();
-    ModuleUserUtils.getOperationUser(req, "submit jobReqId: " + jobReqId);
-    pushLog(
-        LogUtils.generateInfo(
-            "Your job is accepted,  jobID is "
-                + job.getId()
-                + " and jobReqId is "
-                + jobReqId
-                + " in "
-                + Sender.getThisServiceInstance().toString()
-                + ". \n Please wait it to be scheduled(您的任务已经提交，进入排队中，如果一直没有更新日志，是任务并发达到了限制，可以在ITSM提Linkis参数修改单)"),
-        job);
-    String execID =
-        ZuulEntranceUtils.generateExecID(
-            job.getId(),
-            Sender.getThisServiceInstance().getApplicationName(),
-            new String[] {Sender.getThisInstance()});
-    message = Message.ok();
-    message.setMethod("/api/entrance/submit");
-    message.data("execID", execID);
-    message.data("taskID", jobReqId);
-    logger.info("End to get an an execID: {}, taskID: {}", execID, jobReqId);
+    LoggerUtils.setJobIdMDC(String.valueOf(jobReqId));
+    try {
+      ModuleUserUtils.getOperationUser(req, "submit jobReqId: " + jobReqId);
+      pushLog(
+          LogUtils.generateInfo(
+              "Your job is accepted,  jobID is "
+                  + job.getId()
+                  + " and jobReqId is "
+                  + jobReqId
+                  + " in "
+                  + Sender.getThisServiceInstance().toString()
+                  + ". \n Please wait it to be scheduled(您的任务已经提交，进入排队中，如果一直没有更新日志，是任务并发达到了限制，可以在ITSM提Linkis参数修改单)"),
+          job);
+      String execID =
+          ZuulEntranceUtils.generateExecID(
+              job.getId(),
+              Sender.getThisServiceInstance().getApplicationName(),
+              new String[] {Sender.getThisInstance()});
+      message = Message.ok();
+      message.setMethod("/api/entrance/submit");
+      message.data("execID", execID);
+      message.data("taskID", jobReqId);
+      logger.info("End to get an an execID: {}, taskID: {}", execID, jobReqId);
+    } finally {
+      LoggerUtils.removeJobIdMDC();
+    }
     return message;
   }
 

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/EntranceServer.scala
@@ -106,9 +106,8 @@ abstract class EntranceServer extends Logging {
         PERSIST_JOBREQUEST_ERROR.getErrorDesc
       )
     }
-    logger.info(s"received a request,convert $jobRequest")
-
     LoggerUtils.setJobIdMDC(jobRequest.getId.toString)
+    logger.info(s"received a request,convert $jobRequest")
 
     val logAppender = new java.lang.StringBuilder()
     Utils.tryThrow(

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceJob.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/execute/EntranceJob.scala
@@ -26,6 +26,7 @@ import org.apache.linkis.entrance.event._
 import org.apache.linkis.entrance.exception.EntranceErrorException
 import org.apache.linkis.governance.common.entity.job.JobRequest
 import org.apache.linkis.governance.common.paser.CodeParser
+import org.apache.linkis.governance.common.utils.LoggerUtils
 import org.apache.linkis.protocol.constants.TaskConstant
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.rpc.utils.RPCUtils
@@ -123,6 +124,18 @@ abstract class EntranceJob extends Job {
 
   protected def isWaitForPersistedTimeout(startWaitForPersistedTime: Long): Boolean =
     System.currentTimeMillis - startWaitForPersistedTime >= EntranceConfiguration.JOB_MAX_PERSIST_WAIT_TIME.getValue.toLong
+
+  override protected def transition(state: SchedulerEventState): Unit = {
+    val jobRequest = getJobRequest
+    if (jobRequest != null && jobRequest.getId != null && jobRequest.getId > 0) {
+      LoggerUtils.setJobIdMDC(jobRequest.getId.toString)
+    }
+    try {
+      super.transition(state)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
+  }
 
   override def beforeStateChanged(
       fromState: SchedulerEventState,

--- a/linkis-public-enhancements/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
+++ b/linkis-public-enhancements/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
@@ -30,6 +30,7 @@ import org.apache.linkis.governance.common.entity.job.{
 }
 import org.apache.linkis.governance.common.protocol.conf.EntranceInstanceConfRequest
 import org.apache.linkis.governance.common.protocol.job._
+import org.apache.linkis.governance.common.utils.LoggerUtils
 import org.apache.linkis.jobhistory.conf.JobhistoryConfiguration
 import org.apache.linkis.jobhistory.conversions.TaskConversions._
 import org.apache.linkis.jobhistory.dao.JobHistoryMapper
@@ -154,79 +155,86 @@ class JobHistoryQueryServiceImpl extends JobHistoryQueryService with Logging {
   override def change(jobReqUpdate: JobReqUpdate): JobRespProtocol = {
     val jobReq = jobReqUpdate.jobReq
     jobReq.setExecutionCode(null)
-    logger.info(
-      "Update data to the database(往数据库中更新数据)：task " + jobReq.getId + "status:" + jobReq.getStatus
-    )
+    if (jobReq.getId != null) {
+      LoggerUtils.setJobIdMDC(jobReq.getId.toString)
+    }
     val jobResp = new JobRespProtocol
-    Utils.tryCatch {
-      if (jobReq.getErrorDesc != null) {
-        if (jobReq.getErrorDesc.length > GovernanceCommonConf.ERROR_CODE_DESC_LEN) {
-          logger.info(s"errorDesc is too long,we will cut some message")
-          jobReq.setErrorDesc(
-            jobReq.getErrorDesc.substring(0, GovernanceCommonConf.ERROR_CODE_DESC_LEN - 3) + "..."
-          )
-          logger.info(s"${jobReq.getErrorDesc}")
-        }
-      }
-      if (jobReq.getStatus != null) {
-        val oldStatus: String = jobHistoryMapper.selectJobHistoryStatusForUpdate(jobReq.getId)
-        val startUpMap: util.Map[String, AnyRef] =
-          TaskUtils.getStartupMap(jobReqUpdate.jobReq.getParams)
-        val taskRetrySwitch: AnyRef = startUpMap.getOrDefault("linkis.task.retry.switch", "false")
-        if (
-            oldStatus != null && !shouldUpdate(
-              oldStatus,
-              jobReq.getStatus,
-              taskRetrySwitch.toString
+    try {
+      logger.info(
+        "Update data to the database(往数据库中更新数据)：task " + jobReq.getId + "status:" + jobReq.getStatus
+      )
+      Utils.tryCatch {
+        if (jobReq.getErrorDesc != null) {
+          if (jobReq.getErrorDesc.length > GovernanceCommonConf.ERROR_CODE_DESC_LEN) {
+            logger.info(s"errorDesc is too long,we will cut some message")
+            jobReq.setErrorDesc(
+              jobReq.getErrorDesc.substring(0, GovernanceCommonConf.ERROR_CODE_DESC_LEN - 3) + "..."
             )
+            logger.info(s"${jobReq.getErrorDesc}")
+          }
+        }
+        if (jobReq.getStatus != null) {
+          val oldStatus: String = jobHistoryMapper.selectJobHistoryStatusForUpdate(jobReq.getId)
+          val startUpMap: util.Map[String, AnyRef] =
+            TaskUtils.getStartupMap(jobReqUpdate.jobReq.getParams)
+          val taskRetrySwitch: AnyRef = startUpMap.getOrDefault("linkis.task.retry.switch", "false")
+          if (
+              oldStatus != null && !shouldUpdate(
+                oldStatus,
+                jobReq.getStatus,
+                taskRetrySwitch.toString
+              )
+          ) {
+            throw new QueryException(
+              120001,
+              s"jobId:${jobReq.getId}，oldStatus(在数据库中的task状态为)：${oldStatus}," +
+                s" newStatus(更新的task状态为)：${jobReq.getStatus}，update failed(更新失败)！"
+            )
+          }
+        }
+
+        // metrics 增量更新逻辑
+        if (
+            Configuration.METRICS_INCREMENTAL_UPDATE_ENABLE.getValue &&
+            jobReq.getMetrics != null && !jobReq.getMetrics.isEmpty
         ) {
+          mergeMetrics(jobReq)
+        }
+
+        val jobUpdate = jobRequest2JobHistory(jobReq)
+        if (jobUpdate.getUpdatedTime == null) {
           throw new QueryException(
             120001,
-            s"jobId:${jobReq.getId}，oldStatus(在数据库中的task状态为)：${oldStatus}," +
-              s" newStatus(更新的task状态为)：${jobReq.getStatus}，update failed(更新失败)！"
+            s"jobId:${jobReq.getId}，update job failed, updatetime needed(更新job相关信息失败，请指定该请求的更新时间)!"
           )
         }
-      }
-
-      // metrics 增量更新逻辑
-      if (
-          Configuration.METRICS_INCREMENTAL_UPDATE_ENABLE.getValue &&
-          jobReq.getMetrics != null && !jobReq.getMetrics.isEmpty
-      ) {
-        mergeMetrics(jobReq)
-      }
-
-      val jobUpdate = jobRequest2JobHistory(jobReq)
-      if (jobUpdate.getUpdatedTime == null) {
-        throw new QueryException(
-          120001,
-          s"jobId:${jobReq.getId}，update job failed, updatetime needed(更新job相关信息失败，请指定该请求的更新时间)!"
+        logger.info(
+          s"Update data to the database(往数据库中更新数据)：task ${jobReq.getId} ,status ${jobReq.getStatus}," +
+            s" updateTime: ${jobUpdate.getUpdateTimeMills}, progress : ${jobUpdate.getProgress}"
         )
+        jobHistoryMapper.updateJobHistory(jobUpdate)
+        val map = new util.HashMap[String, Object]
+        map.put(JobRequestConstants.JOB_ID, jobReq.getId.asInstanceOf[Object])
+        jobResp.setStatus(0)
+        jobResp.setData(map)
+      } {
+        case exception: QueryException =>
+          logger.error(
+            s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
+            exception
+          )
+          jobResp.setStatus(1)
+          jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
+        case exception: Exception =>
+          logger.error(
+            s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
+            exception
+          )
+          jobResp.setStatus(2)
+          jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
       }
-      logger.info(
-        s"Update data to the database(往数据库中更新数据)：task ${jobReq.getId} ,status ${jobReq.getStatus}," +
-          s" updateTime: ${jobUpdate.getUpdateTimeMills}, progress : ${jobUpdate.getProgress}"
-      )
-      jobHistoryMapper.updateJobHistory(jobUpdate)
-      val map = new util.HashMap[String, Object]
-      map.put(JobRequestConstants.JOB_ID, jobReq.getId.asInstanceOf[Object])
-      jobResp.setStatus(0)
-      jobResp.setData(map)
-    } {
-      case exception: QueryException =>
-        logger.error(
-          s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
-          exception
-        )
-        jobResp.setStatus(1)
-        jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
-      case exception: Exception =>
-        logger.error(
-          s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
-          exception
-        )
-        jobResp.setStatus(2)
-        jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
+    } finally {
+      LoggerUtils.removeJobIdMDC()
     }
     jobResp
   }


### PR DESCRIPTION
## Summary
- 在任务执行全流程中，部分与任务强关联的日志未打印 JobId（MDC 中未设置），导致跨服务日志追踪困难
- 本次修改在已有 taskId 上下文但未设置 MDC 的位置添加 setJobIdMDC/removeJobIdMDC，属于最小化改动

## Changes
| 文件 | 改动说明 |
|------|----------|
| EntranceServer.scala | 将 setJobIdMDC 移到 logger.info 之前，使 received a request 日志带上 JobId |
| EntranceRestfulApi.java | submit() 和 execute() 方法中获取 jobReqId 后立即设置 MDC，finally 清理 |
| EntranceJob.scala | 重写 transition() 方法，在状态变更日志前设置 MDC |
| JobHistoryQueryServiceImpl.scala | change() 方法入口设置 MDC，finally 清理 |
| TaskExecutionServiceImpl.scala | 给 dealRequestTaskKill/Status/Pause/Resume 4 个 @Receiver 方法添加 MDC |

## Test plan
- [x] 编译验证通过（mvn compile）
- [ ] 提交 shell 任务，验证各服务日志中 JobId 覆盖率提升
- [ ] 检查 MDC 清理是否正确，无泄漏到无关线程

🤖 Generated with [Claude Code](https://claude.com/claude-code)