### PR TITLE
[chore][COM][core] downgrade flink version from 1.16.2 to 1.12.2 for compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 
     <!-- Query Engines -->
     <hive.version>2.3.3</hive.version>
-    <flink.version>1.16.2</flink.version>
+    <flink.version>1.12.2</flink.version>
     <trino.version>371</trino.version>
     <impala.version>3.4.0.7.2.15.0-147</impala.version>
     <presto.version>0.234</presto.version>
@@ -1705,7 +1705,7 @@
         <jline.version>2.14.6</jline.version>
         <woodstox.version>6.4.0</woodstox.version>
         <sparkmeasure.version>0.24</sparkmeasure.version>
-        <flink.version>1.16.2</flink.version>
+        <flink.version>1.12.2</flink.version>
 
         <!-- Cloud Storage -->
         <hadoop-aliyun.version>3.3.4</hadoop-aliyun.version>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
Flink version 1.16.2 has compatibility issues with certain production environments, specifically with Hadoop 3.3.4 and related ecosystem components. The newer Flink version introduces dependency conflicts and runtime issues that affect system stability.

**Purpose of Change:**
To resolve these compatibility issues, this PR downgrades the Flink version from 1.16.2 to 1.12.2, which has been tested and verified to work correctly with the current Hadoop environment and dependent libraries.

**Value/Impact:**
After this change, Linkis will have better compatibility with the production Hadoop ecosystem, reducing runtime errors and improving overall system stability for Flink-based workloads.

### Related issues/PRs

Related issues: close #1012
Related pr:none

### Brief change log

- Downgrade flink.version from 1.16.2 to 1.12.12 in root pom.xml

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.