### PR TITLE
[feat][PES][instance-label-server] add broadcast trigger when entrance service labels are modified

### DIFF
--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
@@ -63,6 +63,9 @@ object Configuration extends Logging {
   val JOBHISTORY_SPRING_APPLICATION_NAME =
     CommonVars("wds.linkis.jobhistory.application.name", "linkis-ps-jobhistory")
 
+  val CLOUD_CONSOLE_ENTRANCE_SPRING_APPLICATION_NAME =
+    CommonVars("wds.linkis.console.entrance.application.name", "linkis-cg-entrance")
+
   // read from env
   val PREFER_IP_ADDRESS: Boolean = CommonVars(
     "linkis.discovery.prefer-ip-address",
@@ -138,6 +141,13 @@ object Configuration extends Logging {
    */
   val SECONDARY_QUEUE_CREATORS: CommonVars[String] =
     CommonVars.apply("wds.linkis.rm.secondary.yarnqueue.creators", "IDE")
+
+  /**
+   * Entrance Group缓存清理功能总开关 控制以下功能是否启用：
+   *   1. Entrance offline时发送Group缓存清理广播 2. 接收并处理Group缓存清理广播 3. 手动清理Group缓存API
+   */
+  val ENTRANCE_GROUP_CACHE_CLEAR_ENABLED =
+    CommonVars[Boolean]("linkis.entrance.group.cache.clear.enabled", true).getValue
 
   val EXECUTE_ERROR_CODE_INDEX =
     CommonVars("execute.error.code.index", "-1")

--- a/linkis-commons/linkis-protocol/src/main/scala/org/apache/linkis/protocol/label/EntranceGroupCacheClearBroadcast.scala
+++ b/linkis-commons/linkis-protocol/src/main/scala/org/apache/linkis/protocol/label/EntranceGroupCacheClearBroadcast.scala
@@ -15,25 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.linkis.entrance.protocol
+package org.apache.linkis.protocol.label
 
 import org.apache.linkis.protocol.BroadcastProtocol
 
 /**
  * Entrance Group缓存清除广播消息
  *
- * 广播时机：Entrance实例offline时（通过/markoffline接口触发） 广播目的：通知所有其他Entrance实例清除本地Group缓存
- * 广播效果：下次任务提交时重新计算并发数，排除offline实例
+ * 广播时机：
+ *   1. Entrance实例offline时（通过/markoffline接口触发） 2. 通过InstanceLabel管理接口更新Entrance实例标签时
+ *
+ * 广播目的：通知所有其他Entrance实例清除本地Group缓存 广播效果：下次任务提交时重新计算并发数
  *
  * @param instance
- *   offline的Entrance实例标识
+ *   触发广播的Entrance实例标识
  * @param timestamp
  *   广播发送时间戳（毫秒）
  */
 case class EntranceGroupCacheClearBroadcast(instance: String, timestamp: Long)
     extends BroadcastProtocol {
 
-  // 不抛出任何异常，即使部分实例接收失败也不影响offline流程
+  // 不抛出任何异常，即使部分实例接收失败也不影响流程
   override val throwsIfAnyFailed: Boolean = false
 
 }

--- a/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceLabelRestfulApi.java
+++ b/linkis-computation-governance/linkis-entrance/src/main/java/org/apache/linkis/entrance/restful/EntranceLabelRestfulApi.java
@@ -22,12 +22,12 @@ import org.apache.linkis.common.ServiceInstance;
 import org.apache.linkis.common.conf.Configuration;
 import org.apache.linkis.entrance.EntranceServer;
 import org.apache.linkis.entrance.conf.EntranceConfiguration;
-import org.apache.linkis.entrance.protocol.EntranceGroupCacheClearBroadcast;
 import org.apache.linkis.entrance.scheduler.EntranceSchedulerContext;
 import org.apache.linkis.instance.label.client.InstanceLabelClient;
 import org.apache.linkis.manager.label.constant.LabelKeyConstant;
 import org.apache.linkis.manager.label.constant.LabelValueConstant;
 import org.apache.linkis.manager.label.entity.Label;
+import org.apache.linkis.protocol.label.EntranceGroupCacheClearBroadcast;
 import org.apache.linkis.protocol.label.InsLabelRefreshRequest;
 import org.apache.linkis.protocol.label.InsLabelRemoveRequest;
 import org.apache.linkis.rpc.Sender;
@@ -103,7 +103,7 @@ public class EntranceLabelRestfulApi {
       offlineFlag = true;
     }
     // 只有当功能开关启用时才发送缓存清理广播
-    if (EntranceConfiguration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED()) {
+    if (Configuration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED()) {
       try {
         // 构造广播消息
         EntranceGroupCacheClearBroadcast broadcast =
@@ -145,7 +145,7 @@ public class EntranceLabelRestfulApi {
     insLabelRemoveRequest.setServiceInstance(Sender.getThisServiceInstance());
     InstanceLabelClient.getInstance().removeLabelsFromInstance(insLabelRemoveRequest);
     // 只有当功能开关启用时才发送缓存清理广播
-    if (EntranceConfiguration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED()) {
+    if (Configuration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED()) {
       try {
         // 构造广播消息
         EntranceGroupCacheClearBroadcast broadcast =

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/conf/EntranceConfiguration.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/conf/EntranceConfiguration.scala
@@ -420,6 +420,7 @@ object EntranceConfiguration {
   var SPARK_DYNAMIC_ALLOCATION_ENABLED =
     CommonVars.apply("spark.dynamic.allocation.enabled", false).getValue
 
+
   var SPARK_DYNAMIC_ALLOCATION_ADDITIONAL_CONFS =
     CommonVars.apply("spark.dynamic.allocation.additional.confs", "").getValue
 
@@ -467,15 +468,6 @@ object EntranceConfiguration {
   val HIVE_LOCATION_CONTROL_WHITELIST_CREATORS: CommonVars[String] =
     CommonVars("wds.linkis.hive.location.control.whitelist.creators", "")
 
-  /**
-   * Entrance Group缓存清理功能总开关
-   *
-   * 控制以下功能是否启用：
-   *   1. Entrance offline时发送Group缓存清理广播 2. 接收并处理Group缓存清理广播 3. 手动清理Group缓存API
-   *
-   * 默认关闭，需要手动启用以验证功能稳定性
-   */
-  val ENTRANCE_GROUP_CACHE_CLEAR_ENABLED =
-    CommonVars[Boolean]("linkis.entrance.group.cache.clear.enabled", true).getValue
+
 
 }

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/listener/EntranceGroupCacheClearBroadcastListener.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/listener/EntranceGroupCacheClearBroadcastListener.scala
@@ -17,14 +17,13 @@
 
 package org.apache.linkis.entrance.listener
 
+import org.apache.linkis.common.conf.Configuration
 import org.apache.linkis.common.utils.Logging
-import org.apache.linkis.entrance.conf.EntranceConfiguration
-import org.apache.linkis.entrance.protocol.EntranceGroupCacheClearBroadcast
 import org.apache.linkis.entrance.scheduler.EntranceGroupFactory
 import org.apache.linkis.protocol.BroadcastProtocol
+import org.apache.linkis.protocol.label.EntranceGroupCacheClearBroadcast
 import org.apache.linkis.rpc.BroadcastListener
 import org.apache.linkis.rpc.Sender
-
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
@@ -46,7 +45,7 @@ class EntranceGroupCacheClearBroadcastListener extends BroadcastListener with Lo
     protocol match {
       case clear: EntranceGroupCacheClearBroadcast =>
         logger.info(s"Received cache clear broadcast from ${clear.instance} at ${clear.timestamp}")
-        if (EntranceConfiguration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED) {
+        if (Configuration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED) {
           try {
             // 清除所有Group缓存
             entranceGroupFactory.clearAllGroupCache()

--- a/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/scheduler/EntranceGroupFactory.scala
+++ b/linkis-computation-governance/linkis-entrance/src/main/scala/org/apache/linkis/entrance/scheduler/EntranceGroupFactory.scala
@@ -151,7 +151,7 @@ class EntranceGroupFactory extends GroupFactory with Logging {
   def clearAllGroupCache(): Unit = {
     try {
       // 检查功能开关是否启用
-      if (EntranceConfiguration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED) {
+      if (Configuration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED) {
         val cacheSize = groupNameToGroups.size()
         groupNameToGroups.invalidateAll()
         logger.info(s"Cleared all Group cache. Cache size before clear: $cacheSize")

--- a/linkis-public-enhancements/linkis-instance-label-server/src/main/java/org/apache/linkis/instance/label/conf/InsLabelConf.java
+++ b/linkis-public-enhancements/linkis-instance-label-server/src/main/java/org/apache/linkis/instance/label/conf/InsLabelConf.java
@@ -48,4 +48,7 @@ public class InsLabelConf {
 
   public static final CommonVars<String> SERVICE_REGISTRY_ADDRESS =
       CommonVars.apply("linkis.discovery.server-address", "http://localhost:20303");
+
+  /** Entrance service application name */
+  public static final String ENTRANCE_SERVICE_NAME = "linkis-cg-entrance";
 }

--- a/linkis-public-enhancements/linkis-instance-label-server/src/main/java/org/apache/linkis/instance/label/restful/InstanceRestful.java
+++ b/linkis-public-enhancements/linkis-instance-label-server/src/main/java/org/apache/linkis/instance/label/restful/InstanceRestful.java
@@ -29,6 +29,8 @@ import org.apache.linkis.manager.label.builder.factory.LabelBuilderFactoryContex
 import org.apache.linkis.manager.label.entity.Label;
 import org.apache.linkis.manager.label.entity.UserModifiable;
 import org.apache.linkis.manager.label.utils.LabelUtils;
+import org.apache.linkis.protocol.label.EntranceGroupCacheClearBroadcast;
+import org.apache.linkis.rpc.Sender;
 import org.apache.linkis.server.Message;
 import org.apache.linkis.server.utils.ModuleUserUtils;
 
@@ -149,6 +151,15 @@ public class InstanceRestful {
     InstanceInfo instanceInfo = insLabelService.getInstanceInfoByServiceInstance(instance);
     instanceInfo.setUpdateTime(new Date());
     insLabelService.updateInstance(instanceInfo);
+
+    // If the instance is an Entrance service, trigger cache clear broadcast
+    if (Configuration.ENTRANCE_GROUP_CACHE_CLEAR_ENABLED()
+        && Configuration.CLOUD_CONSOLE_ENTRANCE_SPRING_APPLICATION_NAME()
+            .getValue()
+            .equalsIgnoreCase(instanceType)) {
+      triggerEntranceCacheClearBroadcast(instanceName);
+    }
+
     return Message.ok("success").data("labels", labels);
   }
 
@@ -206,5 +217,28 @@ public class InstanceRestful {
           instanceList.filter(s -> s.getMetadata().get("linkis.app.version").contains(version));
     }
     return Message.ok().data("list", instanceList.collect(Collectors.toList()));
+  }
+
+  /**
+   * Trigger Entrance Group cache clear broadcast via RPC.
+   *
+   * <p>When an Entrance instance's labels are updated, all other Entrance instances need to clear
+   * their local Group cache so that the next task submission will recalculate concurrency settings
+   * based on the updated labels.
+   *
+   * @param instanceName the instance identifier that triggered the broadcast
+   */
+  private void triggerEntranceCacheClearBroadcast(String instanceName) {
+    try {
+      EntranceGroupCacheClearBroadcast broadcast =
+          new EntranceGroupCacheClearBroadcast(instanceName, System.currentTimeMillis());
+      Sender.getSender(Configuration.CLOUD_CONSOLE_ENTRANCE_SPRING_APPLICATION_NAME().getValue())
+          .send(broadcast);
+      logger.info("Successfully sent Entrance cache clear broadcast for instance: " + instanceName);
+    } catch (Exception e) {
+      // Broadcast failure should not affect the label update flow
+      logger.error(
+          "Failed to send Entrance cache clear broadcast for instance: " + instanceName, e);
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
When an Entrance instance's labels are modified through the InstanceLabelService, other Entrance instances in the cluster are not notified of the change. This causes stale Group cache information across the cluster, leading to incorrect user task concurrency calculations since other instances continue using outdated label-based concurrency settings.

**Purpose of Change:**
To address this problem, this PR adds a broadcast trigger mechanism in the InstanceLabelService. When an Entrance instance's labels are updated, the service automatically sends a broadcast notification to all other Entrance instances, instructing them to clear their local Group cache.

**Value/Impact:**
After this change, all Entrance instances will maintain consistent Group cache information, ensuring accurate user task concurrency calculations across the cluster and preventing resource allocation issues caused by stale cache data.

### Related issues/PRs

Related issues: close #1016
Related pr:none

### Brief change log

- Add broadcast trigger in InstanceRestful when Entrance labels are updated
- Move EntranceGroupCacheClearBroadcast from entrance to protocol module
- Add configuration options for enabling/disabling broadcast feature
- Update EntranceGroupCacheClearBroadcastListener to use protocol-based broadcast class
- Add exception handling to ensure broadcast failures don't affect label updates

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.