### PR TITLE
[chore][COM][core] remove commons-lang and upgrade commons-lang3 to 3.18.0 for security

### DIFF
--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkDataCalcExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkDataCalcExecutor.scala
@@ -35,7 +35,7 @@ import org.apache.linkis.scheduler.executer.{
   SuccessExecuteResponse
 }
 
-import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 import java.lang.reflect.InvocationTargetException
 

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/TenantConfigrationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/TenantConfigrationRestfulApi.java
@@ -26,7 +26,7 @@ import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 import org.apache.linkis.server.Message;
 import org.apache.linkis.server.utils.ModuleUserUtils;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/UserIpConfigrationRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/UserIpConfigrationRestfulApi.java
@@ -25,7 +25,7 @@ import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 import org.apache.linkis.server.Message;
 import org.apache.linkis.server.utils.ModuleUserUtils;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/service/impl/TenantConfigServiceImpl.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/service/impl/TenantConfigServiceImpl.java
@@ -29,7 +29,7 @@ import org.apache.linkis.configuration.util.ClientUtil;
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/service/impl/UserIpConfigServiceImpl.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/service/impl/UserIpConfigServiceImpl.java
@@ -24,7 +24,7 @@ import org.apache.linkis.configuration.service.UserIpConfigService;
 import org.apache.linkis.configuration.util.CommonUtils;
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,7 @@
     <druid.version>1.2.4</druid.version>
     <javassist.version>3.27.0-GA</javassist.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-lang.version>2.6</commons-lang.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-text.version>1.10.0</commons-text.version>
     <commons-math3.version>3.6.1</commons-math3.version>
@@ -401,11 +400,7 @@
         <artifactId>commons-collections</artifactId>
         <version>${commons-collections.version}</version>
       </dependency>
-      <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>${commons-lang.version}</version>
-      </dependency>
+
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The commons-lang library (version 2.6) is outdated and contains known security vulnerabilities. Additionally, the project currently depends on both commons-lang and commons-lang3, which can cause classpath conflicts and API confusion. The commons-lang3 version (3.12.0) in use is also outdated and missing recent security fixes.

**Purpose of Change:**
To address these security and maintenance concerns, this PR removes the commons-lang dependency entirely and upgrades commons-lang3 from version 3.12.0 to 3.18.0. All code references have been updated to use commons-lang3 APIs consistently.

**Value/Impact:**
After this change, the project will have a cleaner dependency structure with no legacy commons-lang usage, reduced security vulnerabilities, and access to the latest bug fixes and improvements in commons-lang3 3.18.0.

### Related issues/PRs

Related issues: close #1018
Related pr:none

### Brief change log

- Remove commons-lang (version 2.6) dependency from root pom.xml
- Upgrade commons-lang3 from 3.12.0 to 3.18.0 in root pom.xml
- Update import statements in SparkDataCalcExecutor.scala from commons-lang to commons-lang3
- Update import statements in TenantConfigrationRestfulApi.java from commons-lang to commons-lang3
- Update import statements in TenantConfigServiceImpl.java from commons-lang to commons-lang3
- Update import statements in UserIpConfigrationRestfulApi.java from commons-lang to commons-lang3
- Update import statements in UserIpConfigServiceImpl.java from commons-lang to commons-lang3

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.