### PR TITLE
[fix][EC][all-engines] enhance user code masking in engine execution logs

### DIFF
--- a/linkis-engineconn-plugins/flink/flink-core/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/InsertOperation.java
+++ b/linkis-engineconn-plugins/flink/flink-core/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/InsertOperation.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl;
 
+import org.apache.linkis.common.utils.CodeUtils;
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
 import org.apache.linkis.engineconnplugin.flink.client.shims.exception.SqlExecutionException;
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.AbstractJobOperation;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.linkis.manager.label.entity.engine.EngineType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +90,7 @@ public class InsertOperation extends AbstractJobOperation {
     try {
       tableResult = executionContext.wrapClassLoader(() -> tableEnv.executeSql(statement));
     } catch (Exception t) {
-      LOG.error(String.format("Invalid SQL query, sql is: %s.", statement), t);
+      LOG.error(String.format("Invalid SQL query, sql is: %s.", CodeUtils.maskCode(statement, EngineType.FLINK().toString())), t);
       // catch everything such that the statement does not crash the executor
       throw new SqlExecutionException(INVALID_SQL_STATEMENT.getErrorDesc(), t);
     }

--- a/linkis-engineconn-plugins/flink/flink-core/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/SelectOperation.java
+++ b/linkis-engineconn-plugins/flink/flink-core/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/SelectOperation.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl;
 
+import org.apache.linkis.common.utils.CodeUtils;
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
 import org.apache.linkis.engineconnplugin.flink.client.result.AbstractResult;
 import org.apache.linkis.engineconnplugin.flink.client.result.BatchResult;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.linkis.manager.label.entity.engine.EngineType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,7 +184,7 @@ public class SelectOperation extends AbstractJobOperation {
       // the result needs to be closed as long as
       // it not stored in the result store
       result.close();
-      LOG.error(String.format("Invalid SQL query, sql is %s.", query), t);
+      LOG.error(String.format("Invalid SQL query, sql is %s.", CodeUtils.maskCode(query, EngineType.FLINK().toString())), t);
       // catch everything such that the query does not crash the executor
       throw new SqlExecutionException(INVALID_SQL_QUERY.getErrorDesc(), t);
     } finally {

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConcurrentConnExecutor.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConcurrentConnExecutor.scala
@@ -20,7 +20,10 @@ package org.apache.linkis.engineplugin.hive.executor
 import org.apache.linkis.common.exception.ErrorException
 import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
-import org.apache.linkis.engineconn.computation.executor.execute.{ConcurrentComputationExecutor, EngineExecutionContext}
+import org.apache.linkis.engineconn.computation.executor.execute.{
+  ConcurrentComputationExecutor,
+  EngineExecutionContext
+}
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.executor.entity.{ConcurrentExecutor, ResourceFetchExecutor}
 import org.apache.linkis.engineplugin.hive.conf.{Counters, HiveEngineConfiguration}
@@ -33,21 +36,36 @@ import org.apache.linkis.engineplugin.hive.exception.HiveQueryFailedException
 import org.apache.linkis.governance.common.paser.SQLCodeParser
 import org.apache.linkis.governance.common.utils.JobUtils
 import org.apache.linkis.hadoop.common.conf.HadoopConf
-import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, LoadInstanceResource, NodeResource}
+import org.apache.linkis.manager.common.entity.resource.{
+  CommonNodeResource,
+  LoadInstanceResource,
+  NodeResource
+}
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.protocol.engine.JobProgressInfo
-import org.apache.linkis.scheduler.executer.{CompletedExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
+import org.apache.linkis.scheduler.executer.{
+  CompletedExecuteResponse,
+  ErrorExecuteResponse,
+  ExecuteResponse,
+  SuccessExecuteResponse
+}
 import org.apache.linkis.storage.domain.{Column, DataType}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.metastore.api.{FieldSchema, Schema}
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.exec.mr.HadoopJobExecHelper
-import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorFactory, CommandProcessorResponse}
+import org.apache.hadoop.hive.ql.processors.{
+  CommandProcessor,
+  CommandProcessorFactory,
+  CommandProcessorResponse
+}
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.mapred.{JobStatus, RunningJob}
 import org.apache.hadoop.security.UserGroupInformation
@@ -55,12 +73,19 @@ import org.apache.hadoop.security.UserGroupInformation
 import java.io.ByteArrayOutputStream
 import java.security.PrivilegedExceptionAction
 import java.util
-import java.util.concurrent.{Callable, ConcurrentHashMap, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{
+  Callable,
+  ConcurrentHashMap,
+  LinkedBlockingQueue,
+  ThreadPoolExecutor,
+  TimeUnit
+}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.slf4j.LoggerFactory
 
 class HiveEngineConcurrentConnExecutor(
@@ -111,13 +136,16 @@ class HiveEngineConcurrentConnExecutor(
       engineExecutorContext: EngineExecutionContext,
       code: String
   ): ExecuteResponse = {
-    LOG.info(s"HiveEngineConcurrentConnExecutor Ready to executeLine: $code")
+    LOG.info(s"HiveEngineConcurrentConnExecutor Ready to executeLine: ${CodeUtils
+      .maskCode(code, EngineType.HIVE.toString())}")
     val taskId: String = engineExecutorContext.getJobId.getOrElse("udf_init")
     CSHiveHelper.setContextIDInfoToHiveConf(engineExecutorContext, hiveConf)
 
     val realCode = code.trim()
 
-    LOG.info(s"hive client begins to run hql code:\n ${realCode.trim}")
+    LOG.info(
+      s"hive client begins to run hql code:\n ${CodeUtils.maskCode(realCode.trim, EngineType.HIVE.toString())}"
+    )
     val jobId = JobUtils.getJobIdFromMap(engineExecutorContext.getProperties)
     if (StringUtils.isNotBlank(jobId)) {
       // Get username from engineExecutorContext
@@ -213,11 +241,11 @@ class HiveEngineConcurrentConnExecutor(
             var compileRet = -1
             Utils.tryCatch {
               compileRet = driver.compile(realCode)
-              logger.info(
-                s"driver compile realCode : \n ${realCode} \n finished, status : ${compileRet}"
-              )
+              logger.info(s"driver compile realCode : \n ${CodeUtils
+                .maskCode(realCode, EngineType.HIVE.toString())} \n finished, status : ${compileRet}")
               if (0 != compileRet) {
-                logger.warn(s"compile realCode : \n ${CodeUtils.maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
+                logger.warn(s"compile realCode : \n ${CodeUtils
+                  .maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
                 throw HiveQueryFailedException(
                   COMPILE_HIVE_QUERY_ERROR.getErrorCode,
                   COMPILE_HIVE_QUERY_ERROR.getErrorDesc

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
@@ -21,14 +21,20 @@ import org.apache.linkis.common.exception.ErrorException
 import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
-import org.apache.linkis.engineconn.computation.executor.execute.{ComputationExecutor, EngineExecutionContext}
+import org.apache.linkis.engineconn.computation.executor.execute.{
+  ComputationExecutor,
+  EngineExecutionContext
+}
 import org.apache.linkis.engineconn.computation.executor.utlis.ProgressUtils
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.executor.entity.ResourceFetchExecutor
 import org.apache.linkis.engineplugin.hive.conf.{Counters, HiveEngineConfiguration}
 import org.apache.linkis.engineplugin.hive.conf.HiveEngineConfiguration.HIVE_TAG_USER_ENABLE
 import org.apache.linkis.engineplugin.hive.cs.CSHiveHelper
-import org.apache.linkis.engineplugin.hive.errorcode.HiveErrorCodeSummary.{COMPILE_HIVE_QUERY_ERROR, GET_FIELD_SCHEMAS_ERROR}
+import org.apache.linkis.engineplugin.hive.errorcode.HiveErrorCodeSummary.{
+  COMPILE_HIVE_QUERY_ERROR,
+  GET_FIELD_SCHEMAS_ERROR
+}
 import org.apache.linkis.engineplugin.hive.exception.HiveQueryFailedException
 import org.apache.linkis.engineplugin.hive.progress.HiveProgressHelper
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants
@@ -39,11 +45,17 @@ import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, Nod
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.protocol.engine.JobProgressInfo
-import org.apache.linkis.scheduler.executer.{ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
+import org.apache.linkis.scheduler.executer.{
+  ErrorExecuteResponse,
+  ExecuteResponse,
+  SuccessExecuteResponse
+}
 import org.apache.linkis.storage.domain.{Column, DataType}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
+
 import org.apache.commons.collections.MapUtils
 import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.hive.common.HiveInterruptUtils
@@ -54,19 +66,24 @@ import org.apache.hadoop.hive.ql.exec.Task.TaskState
 import org.apache.hadoop.hive.ql.exec.Utilities
 import org.apache.hadoop.hive.ql.exec.mr.HadoopJobExecHelper
 import org.apache.hadoop.hive.ql.exec.tez.TezJobExecHelper
-import org.apache.hadoop.hive.ql.processors.{CommandProcessor, CommandProcessorFactory, CommandProcessorResponse}
+import org.apache.hadoop.hive.ql.processors.{
+  CommandProcessor,
+  CommandProcessorFactory,
+  CommandProcessorResponse
+}
 import org.apache.hadoop.hive.ql.session.SessionState
 import org.apache.hadoop.mapred.{JobStatus, RunningJob}
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.linkis.manager.label.entity.engine.EngineType
 
 import java.io.ByteArrayOutputStream
 import java.security.PrivilegedExceptionAction
 import java.util
 import java.util.concurrent.atomic.AtomicBoolean
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+
 import org.slf4j.LoggerFactory
 
 class HiveEngineConnExecutor(
@@ -146,7 +163,9 @@ class HiveEngineConnExecutor(
     singleCodeCompleted.set(false)
     currentSqlProgress = 0.0f
     val realCode = code.trim()
-    LOG.info(s"hive client begins to run hql code:\n ${realCode.trim}")
+    LOG.info(
+      s"hive client begins to run hql code:\n ${CodeUtils.maskCode(realCode.trim, EngineType.HIVE.toString())}"
+    )
     val jobId = JobUtils.getJobIdFromMap(engineExecutorContext.getProperties)
 
     if (StringUtils.isNotBlank(jobId)) {
@@ -263,11 +282,11 @@ class HiveEngineConnExecutor(
             var compileRet = -1
             Utils.tryCatch {
               compileRet = driver.compile(realCode)
-              logger.info(
-                s"driver compile realCode : \n ${CodeUtils.maskCode(realCode, EngineType.HIVE.toString())} \n finished, status : ${compileRet}"
-              )
+              logger.info(s"driver compile realCode : \n ${CodeUtils
+                .maskCode(realCode, EngineType.HIVE.toString())} \n finished, status : ${compileRet}")
               if (0 != compileRet) {
-                logger.warn(s"compile realCode : \n ${CodeUtils.maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
+                logger.warn(s"compile realCode : \n ${CodeUtils
+                  .maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
                 throw HiveQueryFailedException(
                   COMPILE_HIVE_QUERY_ERROR.getErrorCode,
                   COMPILE_HIVE_QUERY_ERROR.getErrorDesc

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/hook/HiveAddJarsEngineHook.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/hook/HiveAddJarsEngineHook.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineplugin.hive.hook
 
 import org.apache.linkis.common.conf.CommonVars
-import org.apache.linkis.common.utils.{Logging, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.common.creation.EngineCreationContext
 import org.apache.linkis.engineconn.common.engineconn.EngineConn
 import org.apache.linkis.engineconn.common.hook.EngineConnHook
@@ -77,7 +77,7 @@ class HiveAddJarsEngineHook extends EngineConnHook with Logging {
       jars.split(",") foreach { jar =>
         try {
           val sql = addSql + jar
-          logger.info("begin to run hive sql {}", sql)
+          logger.info("begin to run hive sql {}", CodeUtils.maskCode(sql))
           ExecutorManager.getInstance.getExecutorByLabels(labels) match {
             case executor: HiveEngineConnExecutor =>
               executor.executeLine(new EngineExecutionContext(executor), sql)

--- a/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/util/SeatunnelUtils.scala
+++ b/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/util/SeatunnelUtils.scala
@@ -17,11 +17,12 @@
 
 package org.apache.linkis.engineconnplugin.seatunnel.util
 
+import org.apache.linkis.common.utils.CodeUtils
 import org.apache.linkis.engineconn.common.conf.EngineConnConf.ENGINE_CONN_LOCAL_PATH_PWD_KEY
 import org.apache.linkis.engineconnplugin.seatunnel.config.SeatunnelSparkEnvConfiguration
-
 import org.apache.commons.io.IOUtils
 import org.apache.commons.logging.{Log, LogFactory}
+import org.apache.linkis.manager.label.entity.engine.EngineType
 
 import java.io.{BufferedReader, File, InputStreamReader, PrintWriter}
 import java.lang.ProcessBuilder.Redirect
@@ -56,7 +57,7 @@ object SeatunnelUtils {
       processBuilder.redirectOutput(Redirect.appendTo(file))
       LOGGER.info("process ready start.")
       process = processBuilder.start()
-      LOGGER.info(s"process start: $code")
+      LOGGER.info(s"process start: ${CodeUtils.maskCode(code, EngineType.SEATUNNEL.toString)}")
       val exitcode = process.waitFor()
       exitcode
     } finally {

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/imexport/ExportData.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/imexport/ExportData.scala
@@ -17,12 +17,11 @@
 
 package org.apache.linkis.engineplugin.spark.imexport
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.imexport.util.BackGroundServiceUtils
-
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.spark.sql.SparkSession
-
 import org.json4s.{DefaultFormats, _}
 import org.json4s.jackson.JsonMethods._
 
@@ -113,7 +112,7 @@ object ExportData extends Logging {
     sql.append("select ").append(columns).append(" from ").append(s"$database.$tableName")
     if (isPartition) sql.append(" where ").append(s"$partition=$partitionValue")
     val sqlString = sql.toString()
-    logger.warn(s"export sql:$sqlString")
+    logger.warn(s"export sql:${CodeUtils.maskCode(sqlString, EngineType.SPARK.toString)}")
     sqlString
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
Following the initial implementation of code privacy protection in engine logging, additional engine components were identified where user-submitted code is still logged in plain text. Flink SQL operations, Hive engine execution, Seatunnel utilities, and Spark data export still expose user code in log outputs, posing continued security risks.

**Purpose of Change:**
To enhance the code privacy protection coverage, this PR applies CodeUtils.maskCode() to additional engine components including Flink SQL operations (InsertOperation, SelectOperation), Hive engine executors, Hive add jars hook, Seatunnel utilities, and Spark data export functionality.

**Value/Impact:**
After this change, user code masking coverage is extended across more engine types and execution paths, further reducing the risk of sensitive business logic exposure in log files and monitoring systems.

### Related issues/PRs

Related issues: close #999
Related pr: #1003

### Brief change log

- Apply code masking in Flink InsertOperation and SelectOperation
- Enhance code masking in HiveEngineConcurrentConnExecutor with additional scenarios
- Apply code masking in HiveEngineConnExecutor for more execution paths
- Apply code masking in HiveAddJarsEngineHook
- Add code masking in SeatunnelUtils
- Apply code masking in Spark ExportData

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.