### PR TITLE
[fix][PES][datasource] fix datasource oom issue in mdq service partition statistic

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/service/impl/MdqServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/service/impl/MdqServiceImpl.java
@@ -318,39 +318,37 @@ public class MdqServiceImpl implements MdqService {
   public List<MdqTablePartitionStatisticInfoVO> getMdqTablePartitionStatisticInfoVO(
       List<String> partitions, String partitionPath, String partitionSort) {
     // part_name(year=2020/day=0605) => MdqTablePartitionStatisticInfoVO 这里只是返回name，没有相关的分区统计数据
-    ArrayList<MdqTablePartitionStatisticInfoVO> statisticInfoVOS = new ArrayList<>();
+    List<MdqTablePartitionStatisticInfoVO> statisticInfoVOS = new ArrayList<>();
     Map<String, List<Tunple<String, String>>> partitionsStr =
         partitions.stream()
             .map(this::splitStrByFirstSlanting)
             .filter(Objects::nonNull) // 去掉null的
             .collect(Collectors.groupingBy(Tunple::getKey));
-    partitionsStr.forEach(
-        (k, v) -> {
-          MdqTablePartitionStatisticInfoVO mdqTablePartitionStatisticInfoVO =
-              new MdqTablePartitionStatisticInfoVO();
-          mdqTablePartitionStatisticInfoVO.setName(k);
-          String subPartitionPath = String.format("%s/%s", partitionPath, k);
-          mdqTablePartitionStatisticInfoVO.setPartitionPath(subPartitionPath);
-          List<String> subPartitions =
-              v.stream().map(Tunple::getValue).collect(Collectors.toList());
-          List<MdqTablePartitionStatisticInfoVO> childrens =
-              getMdqTablePartitionStatisticInfoVO(subPartitions, subPartitionPath, partitionSort);
-          // 排序
-          if ("asc".equals(partitionSort)) {
-            childrens =
-                childrens.stream()
-                    .sorted(Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName))
-                    .collect(Collectors.toList());
-          } else {
-            childrens =
-                childrens.stream()
-                    .sorted(
-                        Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName).reversed())
-                    .collect(Collectors.toList());
-          }
-          mdqTablePartitionStatisticInfoVO.setChildrens(childrens);
-          statisticInfoVOS.add(mdqTablePartitionStatisticInfoVO);
-        });
+    Comparator<MdqTablePartitionStatisticInfoVO> comparator =
+        "asc".equals(partitionSort)
+            ? Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName)
+            : Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName).reversed();
+    for (Map.Entry<String, List<Tunple<String, String>>> entry : partitionsStr.entrySet()) {
+      MdqTablePartitionStatisticInfoVO mdqTablePartitionStatisticInfoVO =
+          new MdqTablePartitionStatisticInfoVO();
+      mdqTablePartitionStatisticInfoVO.setName(entry.getKey());
+      String subPartitionPath = String.format("%s/%s", partitionPath, entry.getKey());
+      mdqTablePartitionStatisticInfoVO.setPartitionPath(subPartitionPath);
+      List<String> subPartitions =
+          entry.getValue().stream()
+              .map(Tunple::getValue)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+      if (subPartitions.isEmpty()) {
+        mdqTablePartitionStatisticInfoVO.setChildrens(new ArrayList<>());
+      } else {
+        List<MdqTablePartitionStatisticInfoVO> childrens =
+            getMdqTablePartitionStatisticInfoVO(subPartitions, subPartitionPath, partitionSort);
+        childrens.sort(comparator);
+        mdqTablePartitionStatisticInfoVO.setChildrens(childrens);
+      }
+      statisticInfoVOS.add(mdqTablePartitionStatisticInfoVO);
+    }
     return statisticInfoVOS;
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The partition statistic method in MdqServiceImpl uses forEach with Lambda expressions, which can cause OOM (Out of Memory) issues when processing large partitions. The functional programming style creates multiple intermediate objects that increase memory pressure.

**Purpose of Change:**
To address this OOM problem, this PR refactors the `getMdqTablePartitionStatisticInfoVO` method by replacing forEach + Lambda expressions with traditional for-each loops, reducing object creation and improving memory efficiency.

**Value/Impact:**
After the change, the system can handle large partition lists without OOM errors, improving stability and reliability in production environments.

### Related issues/PRs

Related issues: close #1039
Related pr:none

### Brief change log

- Replace forEach + Lambda expressions with traditional for-each loops in getMdqTablePartitionStatisticInfoVO
- Add null pointer filter for subPartitions to improve robustness
- Optimize memory usage by reducing intermediate object creation

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.