### PR TITLE
[perf][CGS][manager] optimize slow sql query in label manager by adding direct label id lookup

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/dao/LabelManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/dao/LabelManagerMapper.java
@@ -116,6 +116,8 @@ public interface LabelManagerMapper {
   List<Map<String, Object>> getNodeRelationsByLabels(
       @Param("labels") List<PersistenceLabel> labels);
 
+  List<Map<String, Object>> getNodeRelationsByLabelIds(@Param("labelIds") List<Integer> labelIds);
+
   /**
    * 通过instance信息，同时返回instance信息和label信息
    *

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/persistence/impl/DefaultLabelManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/persistence/impl/DefaultLabelManagerPersistence.java
@@ -298,11 +298,21 @@ public class DefaultLabelManagerPersistence implements LabelManagerPersistence {
     if (PersistenceUtils.persistenceLabelListIsEmpty(persistenceLabels))
       return Collections.emptyMap();
     try {
-      /*Map<String, Map<String, String>> keyValueMap = PersistenceUtils.filterEmptyPersistenceLabelList(persistenceLabels).stream().collect(Collectors.toMap(PersistenceLabel::getLabelKey, PersistenceLabel::getValue));
-      String dimType = Label.ValueRelation.ALL.name();
-      List<Map<String, Object>> nodeRelationsByLabels = labelManagerMapper.dimListNodeRelationsByKeyValueMap(keyValueMap, dimType);*/
+      // Step 1: 逐个通过 label_key + label_value 查询 label ID（走唯一索引，每次1行）
+      List<Integer> labelIds = new ArrayList<>();
+      for (PersistenceLabel label : persistenceLabels) {
+        PersistenceLabel dbLabel =
+            labelManagerMapper.getLabelByKeyValue(label.getLabelKey(), label.getStringValue());
+        if (dbLabel != null) {
+          labelIds.add(dbLabel.getId());
+        }
+      }
+      if (labelIds.isEmpty()) {
+        return Collections.emptyMap();
+      }
+      // Step 2: 用 label ID 列表查询关联关系（走主键 + idx_lid_instance 索引）
       List<Map<String, Object>> nodeRelationsByLabels =
-          labelManagerMapper.getNodeRelationsByLabels(persistenceLabels);
+          labelManagerMapper.getNodeRelationsByLabelIds(labelIds);
       List<Tunple<PersistenceLabel, ServiceInstance>> arrays =
           new ArrayList<Tunple<PersistenceLabel, ServiceInstance>>();
       for (Map<String, Object> nodeRelationsByLabel : nodeRelationsByLabels) {

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/resources/mapper/common/LabelManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/resources/mapper/common/LabelManagerMapper.xml
@@ -340,6 +340,24 @@
         </foreach>
     </select>
 
+    <select id="getNodeRelationsByLabelIds" resultType="java.util.HashMap">
+        SELECT
+        l.id,
+        l.label_value_size AS 'labelValueSize',
+        l.label_key AS 'labelKey',
+        l.label_value AS 'stringValue',
+        si.instance,
+        si.name AS 'applicationName'
+        FROM
+        linkis_cg_manager_label l
+        INNER JOIN linkis_cg_manager_label_service_instance lsi ON l.id = lsi.label_id
+        INNER JOIN linkis_cg_manager_service_instance si ON si.instance = lsi.service_instance
+        WHERE l.id IN
+        <foreach collection="labelIds" item="labelId" open="(" close=")" separator=",">
+            #{labelId}
+        </foreach>
+    </select>
+
     <select id="listResourceByLaBelId"
             resultType="org.apache.linkis.manager.common.entity.persistence.PersistenceResource">
         SELECT r.* FROM linkis_cg_manager_label_resource lr, linkis_cg_manager_linkis_resources r,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The current implementation of `getNodeRelationsByLabels` method in LabelManagerMapper uses full label objects to query node relations, which can cause slow SQL queries when dealing with large datasets. The query performance is suboptimal due to complex label value comparisons and full table scans.

**Purpose of Change:**
To address this performance issue, this PR adds a new method `getNodeRelationsByLabelIds` that accepts label IDs directly instead of full label objects. The new method uses optimized SQL with INNER JOINs and simple ID-based lookups.

**Value/Impact:**
After the change, query performance is significantly improved when querying node relations for large numbers of labels, reducing database load and improving system responsiveness.

### Related issues/PRs

Related issues: close #1041
Related pr:none

### Brief change log

- Add getNodeRelationsByLabelIds method to LabelManagerMapper interface
- Implement optimized SQL query using INNER JOINs in LabelManagerMapper.xml
- Update DefaultLabelManagerPersistence to support new lookup method
- Optimize query performance by using direct label ID comparisons instead of label value comparisons

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.