### PR TITLE
[fix][COM][logging] add log filtering to prevent token and user code leakage in engine logs

### DIFF
--- a/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/CodeUtils.java
+++ b/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/CodeUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.utils;
+
+import org.apache.linkis.common.conf.Configuration;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Code masking utility for security logging. Prevents sensitive user code from being logged in
+ * plain text.
+ */
+public class CodeUtils {
+
+  /** Default preview length for code snippet (first N characters) */
+  private static final int DEFAULT_CODE_SNIPPET_LENGTH = 6;
+
+  private static final String MSG_EMPTY_CODE = "[empty code]";
+
+  /**
+   * Mask code for logging - only shows length and line count
+   *
+   * @param code the code to mask
+   * @return masked code information
+   */
+  public static String maskCode(String code) {
+    if (!Configuration.CODE_MASK_ENABLED()) {
+      return code;
+    }
+    if (StringUtils.isBlank(code)) {
+      return MSG_EMPTY_CODE;
+    }
+    int length = code.length();
+    int lines = code.split("\n", -1).length;
+    return String.format(
+        "[code length: %d, lines: %d, snippet: %s]",
+        length, lines, getCodeSnippet(code, DEFAULT_CODE_SNIPPET_LENGTH));
+  }
+
+  /**
+   * Mask code for logging - shows type, length, line count, and code snippet
+   *
+   * @param code the code to mask
+   * @param codeType the type of code (e.g., "SQL", "Scala", "Python")
+   * @return masked code information with snippet
+   */
+  public static String maskCode(String code, String codeType) {
+    if (!Configuration.CODE_MASK_ENABLED()) {
+      return code;
+    }
+    if (StringUtils.isBlank(code)) {
+      return MSG_EMPTY_CODE + codeType;
+    }
+    int length = code.length();
+    int lines = code.split("\n", -1).length;
+    return String.format(
+        "[%s code, length: %d, lines: %d, snippet: %s]",
+        codeType, length, lines, getCodeSnippet(code, DEFAULT_CODE_SNIPPET_LENGTH));
+  }
+
+  /**
+   * Get code snippet (first N characters) for debugging
+   *
+   * @param code the code
+   * @param length number of characters to show
+   * @return code snippet (always truncated for security)
+   */
+  public static String getCodeSnippet(String code, int length) {
+    if (StringUtils.isBlank(code)) {
+      return "";
+    }
+    String trimmed = code.trim();
+    // Always truncate for security, even if code is short
+    if (trimmed.length() <= length) {
+      return trimmed + "...";
+    }
+    return trimmed.substring(0, length) + "...";
+  }
+}

--- a/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/TokenSensitiveUtils.java
+++ b/linkis-commons/linkis-common/src/main/java/org/apache/linkis/common/utils/TokenSensitiveUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Token sensitive utility for masking sensitive information in logs.
+ *
+ * <p>This utility provides methods to mask Token information before logging to prevent sensitive
+ * data leakage.
+ *
+ * <p>Configuration: Set linkis.log.token.mask.enable=false to disable token masking.
+ */
+public class TokenSensitiveUtils {
+
+  /**
+   * Mask token for logging purposes.
+   *
+   * <p>Masking rules:
+   *
+   * <ul>
+   *   <li>If token length <= 6: keep first (length-3) characters + "***"
+   *   <li>If token length > 6: keep first 3 characters + "***" + last 3 characters
+   *   <li>If token is null or blank: return original token (fail-safe)
+   *   <li>If masking is disabled via configuration: return original token
+   *   <li>If any exception occurs: return original token (fail-safe)
+   * </ul>
+   *
+   * @param token the token to be masked
+   * @return masked token string, or original token if masking disabled or error occurs
+   */
+  public static String maskToken(String token) {
+    // Return original token if masking is disabled
+    if (!org.apache.linkis.common.conf.Configuration.TOKEN_MASK_ENABLED()) {
+      return token;
+    }
+
+    // Return original token if null or blank (fail-safe)
+    if (StringUtils.isBlank(token)) {
+      return token;
+    }
+
+    try {
+      int length = token.length();
+
+      if (length <= 6) {
+        // Keep first (length-3) characters + "***"
+        int keepLength = Math.max(1, length - 3);
+        return token.substring(0, keepLength) + "***";
+      } else {
+        // Keep first 3 characters + "***" + last 3 characters
+        return token.substring(0, 3) + "***" + token.substring(length - 3);
+      }
+    } catch (Exception e) {
+      // Fail-safe: return original token if any exception occurs
+      return token;
+    }
+  }
+}

--- a/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
+++ b/linkis-commons/linkis-common/src/main/scala/org/apache/linkis/common/conf/Configuration.scala
@@ -104,6 +104,10 @@ object Configuration extends Logging {
 
   val LINKIS_KEYTAB_SWITCH: Boolean = CommonVars("linkis.keytab.switch", false).getValue
 
+  val TOKEN_MASK_ENABLED: Boolean = CommonVars("linkis.log.token.mask.enable", true).getValue
+
+  val CODE_MASK_ENABLED: Boolean = CommonVars("linkis.log.code.mask.enable", true).getValue
+
   val METRICS_INCREMENTAL_UPDATE_ENABLE =
     CommonVars[Boolean]("linkis.jobhistory.metrics.incremental.update.enable", false)
 

--- a/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/utils/TokenSensitiveUtilsTest.java
+++ b/linkis-commons/linkis-common/src/test/java/org/apache/linkis/common/utils/TokenSensitiveUtilsTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.common.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for TokenSensitiveUtils. */
+public class TokenSensitiveUtilsTest {
+
+  @Test
+  @DisplayName("Test masking token with length <= 6")
+  public void testMaskTokenShort() {
+    // Test case 1: length = 3
+    String result1 = TokenSensitiveUtils.maskToken("abc");
+    assertEquals("a***", result1, "Token length 3 should be masked as 'a***'");
+
+    // Test case 2: length = 4
+    String result2 = TokenSensitiveUtils.maskToken("abcd");
+    assertEquals("a***", result2, "Token length 4 should be masked as 'a***'");
+
+    // Test case 3: length = 6
+    String result3 = TokenSensitiveUtils.maskToken("abc123");
+    assertEquals("abc***", result3, "Token length 6 should be masked as 'abc***'");
+  }
+
+  @Test
+  @DisplayName("Test masking token with length > 6")
+  public void testMaskTokenLong() {
+    // Test case 1: length = 12
+    String result1 = TokenSensitiveUtils.maskToken("abc123def456");
+    assertEquals("abc***456", result1, "Token length 12 should be masked as 'abc***456'");
+
+    // Test case 2: length = 20
+    String result2 = TokenSensitiveUtils.maskToken("abc123def456ghi789jk");
+    assertEquals("abc***9jk", result2, "Token length 20 should keep first 3 and last 3 chars");
+
+    // Test case 3: length = 7
+    String result3 = TokenSensitiveUtils.maskToken("abc123d");
+    assertEquals("abc***23d", result3, "Token length 7 should be masked as 'abc***23d'");
+  }
+
+  @Test
+  @DisplayName("Test masking null or empty token (fail-safe: return original)")
+  public void testMaskTokenNullOrEmpty() {
+    // Test case 1: null token - return null (fail-safe)
+    String result1 = TokenSensitiveUtils.maskToken(null);
+    assertNull(result1, "Null token should return null (fail-safe)");
+
+    // Test case 2: empty token - return empty (fail-safe)
+    String result2 = TokenSensitiveUtils.maskToken("");
+    assertEquals("", result2, "Empty token should return empty (fail-safe)");
+
+    // Test case 3: blank token (spaces) - return original (fail-safe)
+    String result3 = TokenSensitiveUtils.maskToken("   ");
+    assertEquals("   ", result3, "Blank token should return original (fail-safe)");
+  }
+
+  @Test
+  @DisplayName("Test masking preserves token length differentiation")
+  public void testMaskTokenLengthDifferentiation() {
+    // Different tokens should produce different masked results
+    String token1 = "abc123";
+    String token2 = "xyz789";
+    String result1 = TokenSensitiveUtils.maskToken(token1);
+    String result2 = TokenSensitiveUtils.maskToken(token2);
+
+    assertNotEquals(result1, result2, "Different tokens should produce different masked results");
+    assertEquals("abc***", result1, "Token length 6 should be masked as 'abc***'");
+    assertEquals("xyz***", result2, "Token length 6 should be masked as 'xyz***'");
+
+    // Test longer tokens also preserve differentiation
+    String token3 = "abc123def456";
+    String token4 = "xyz789ghi012";
+    String result3 = TokenSensitiveUtils.maskToken(token3);
+    String result4 = TokenSensitiveUtils.maskToken(token4);
+    assertNotEquals(
+        result3, result4, "Different long tokens should produce different masked results");
+    assertTrue(result3.startsWith("abc"), "Masked token should start with first 3 chars");
+    assertTrue(result3.endsWith("456"), "Masked token should end with last 3 chars");
+  }
+
+  @Test
+  @DisplayName("Test maskToken handles edge cases")
+  public void testMaskTokenEdgeCases() {
+    // Test case 1: single character
+    String result1 = TokenSensitiveUtils.maskToken("a");
+    assertEquals("a***", result1, "Single char token should be 'a***'");
+
+    // Test case 2: two characters
+    String result2 = TokenSensitiveUtils.maskToken("ab");
+    assertEquals("a***", result2, "Two char token should be 'a***'");
+
+    // Test case 3: very long token
+    String longToken = "abcdefghij1234567890abcdefghij";
+    String result3 = TokenSensitiveUtils.maskToken(longToken);
+    assertTrue(result3.startsWith("abc"), "Long token should start with first 3 chars");
+    assertTrue(result3.endsWith("hij"), "Long token should end with last 3 chars");
+    assertTrue(result3.contains("***"), "Long token should contain '***' in the middle");
+  }
+
+  @Test
+  @DisplayName("Test maskToken handles special characters")
+  public void testMaskTokenSpecialCharacters() {
+    // Test case 1: token with hyphens
+    String result1 = TokenSensitiveUtils.maskToken("abc-123-def");
+    assertTrue(result1.startsWith("abc"), "Token with hyphens should start with first 3 chars");
+    assertTrue(result1.contains("***"), "Token with hyphens should contain '***'");
+
+    // Test case 2: token with underscores
+    String result2 = TokenSensitiveUtils.maskToken("abc_123_def");
+    assertTrue(result2.startsWith("abc"), "Token with underscores should start with first 3 chars");
+    assertTrue(result2.contains("***"), "Token with underscores should contain '***'");
+
+    // Test case 3: token with dots
+    String result3 = TokenSensitiveUtils.maskToken("abc.123.def");
+    assertTrue(result3.startsWith("abc"), "Token with dots should start with first 3 chars");
+    assertTrue(result3.contains("***"), "Token with dots should contain '***'");
+  }
+
+  @Test
+  @DisplayName("Test maskToken is thread-safe (no shared state)")
+  public void testMaskTokenThreadSafe() {
+    // Since maskToken is a static method with no shared state, it should be thread-safe
+    // This test verifies that multiple calls produce consistent results
+    String token = "abc123def456";
+    String result1 = TokenSensitiveUtils.maskToken(token);
+    String result2 = TokenSensitiveUtils.maskToken(token);
+    assertEquals(result1, result2, "Multiple calls with same token should produce same result");
+    assertEquals("abc***456", result1, "Masked token should match expected pattern");
+  }
+}

--- a/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/HDFSFileSystem.java
+++ b/linkis-commons/linkis-storage/src/main/java/org/apache/linkis/storage/fs/impl/HDFSFileSystem.java
@@ -180,42 +180,68 @@ public class HDFSFileSystem extends FileSystem {
   /** FS interface method start */
   @Override
   public void init(Map<String, String> properties) throws IOException {
-    if (MapUtils.isNotEmpty(properties)
-        && properties.containsKey(StorageConfiguration.PROXY_USER().key())) {
-      user = StorageConfiguration.PROXY_USER().getValue(properties);
-      properties.remove(StorageConfiguration.PROXY_USER().key());
-    }
+    long startTime = System.currentTimeMillis();
+    logger.info("Initializing HDFSFileSystem - user: {}, label: {}", user, label);
 
-    if (user == null) {
-      throw new IOException("User cannot be empty(用户不能为空)");
-    }
-    if (label == null && Configuration.IS_MULTIPLE_YARN_CLUSTER()) {
-      label = StorageConfiguration.LINKIS_STORAGE_FS_LABEL().getValue();
-    }
-    /** if properties is null do not to create conf */
-    if (MapUtils.isNotEmpty(properties)) {
-      conf = HDFSUtils.getConfigurationByLabel(user, label);
+    try {
+      if (MapUtils.isNotEmpty(properties)
+          && properties.containsKey(StorageConfiguration.PROXY_USER().key())) {
+        user = StorageConfiguration.PROXY_USER().getValue(properties);
+        properties.remove(StorageConfiguration.PROXY_USER().key());
+      }
+
+      if (user == null) {
+        throw new IOException("User cannot be empty(用户不能为空)");
+      }
+      if (label == null && Configuration.IS_MULTIPLE_YARN_CLUSTER()) {
+        label = StorageConfiguration.LINKIS_STORAGE_FS_LABEL().getValue();
+      }
+      /** if properties is null do not to create conf */
       if (MapUtils.isNotEmpty(properties)) {
-        for (String key : properties.keySet()) {
-          String v = properties.get(key);
-          if (StringUtils.isNotEmpty(v)) {
-            conf.set(key, v);
+        logger.info(
+            "Loading Hadoop configuration with custom properties - user: {}, label: {}, propertiesCount: {}",
+            user,
+            label,
+            properties.size());
+        conf = HDFSUtils.getConfigurationByLabel(user, label);
+        if (MapUtils.isNotEmpty(properties)) {
+          for (String key : properties.keySet()) {
+            String v = properties.get(key);
+            if (StringUtils.isNotEmpty(v)) {
+              conf.set(key, v);
+            }
           }
         }
       }
-    }
-    if (null != conf) {
-      fs = HDFSUtils.getHDFSUserFileSystem(user, label, conf);
-    } else {
-      fs = HDFSUtils.getHDFSUserFileSystem(user, label);
-    }
+      if (null != conf) {
+        fs = HDFSUtils.getHDFSUserFileSystem(user, label, conf);
+      } else {
+        fs = HDFSUtils.getHDFSUserFileSystem(user, label);
+      }
 
-    if (fs == null) {
-      throw new IOException("init HDFS FileSystem failed!");
-    }
-    if (StorageConfiguration.FS_CHECKSUM_DISBALE().getValue()) {
-      fs.setVerifyChecksum(false);
-      fs.setWriteChecksum(false);
+      if (fs == null) {
+        throw new IOException("init HDFS FileSystem failed!");
+      }
+      if (StorageConfiguration.FS_CHECKSUM_DISBALE().getValue()) {
+        fs.setVerifyChecksum(false);
+        fs.setWriteChecksum(false);
+      }
+
+      long duration = System.currentTimeMillis() - startTime;
+      logger.info(
+          "HDFSFileSystem initialized successfully - user: {}, label: {}, duration: {}",
+          user,
+          label,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      logger.error(
+          "Failed to initialize HDFSFileSystem - user: {}, label: {}, duration: {}",
+          user,
+          label,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
     }
   }
 
@@ -336,32 +362,53 @@ public class HDFSFileSystem extends FileSystem {
 
   private void resetRootHdfs() {
     if (fs != null) {
-      String locker = user + LOCKER_SUFFIX;
-      synchronized (locker.intern()) { // NOSONAR
-        if (fs != null) {
-          if (HadoopConf.HDFS_ENABLE_CACHE()) {
-            long currentTime = System.currentTimeMillis();
-            Long lastCallTime = lastCallTimes.get(user);
+      long startTime = System.currentTimeMillis();
+      logger.warn("Resetting HDFS FileSystem connection - user: {}, label: {}", user, label);
 
-            if (lastCallTime != null && (currentTime - lastCallTime) < REFRESH_INTERVAL) {
-              logger.warn(
-                  "Method call denied for username: {} Please wait for {} minutes.",
-                  user,
-                  REFRESH_INTERVAL / 60000);
-              return;
+      try {
+        String locker = user + LOCKER_SUFFIX;
+        synchronized (locker.intern()) { // NOSONAR
+          if (fs != null) {
+            if (HadoopConf.HDFS_ENABLE_CACHE()) {
+              long currentTime = System.currentTimeMillis();
+              Long lastCallTime = lastCallTimes.get(user);
+
+              if (lastCallTime != null && (currentTime - lastCallTime) < REFRESH_INTERVAL) {
+                logger.warn(
+                    "Method call denied for username: {} Please wait for {} minutes.",
+                    user,
+                    REFRESH_INTERVAL / 60000);
+                return;
+              }
+              lastCallTimes.put(user, currentTime);
+              HDFSUtils.closeHDFSFIleSystem(fs, user, label, true);
+            } else {
+              HDFSUtils.closeHDFSFIleSystem(fs, user, label);
             }
-            lastCallTimes.put(user, currentTime);
-            HDFSUtils.closeHDFSFIleSystem(fs, user, label, true);
-          } else {
-            HDFSUtils.closeHDFSFIleSystem(fs, user, label);
-          }
-          logger.warn("{} FS reset close.", user);
-          if (null != conf) {
-            fs = HDFSUtils.getHDFSUserFileSystem(user, label, conf);
-          } else {
-            fs = HDFSUtils.getHDFSUserFileSystem(user, label);
+            logger.warn("{} FS reset close.", user);
+            if (null != conf) {
+              fs = HDFSUtils.getHDFSUserFileSystem(user, label, conf);
+            } else {
+              fs = HDFSUtils.getHDFSUserFileSystem(user, label);
+            }
           }
         }
+
+        long duration = System.currentTimeMillis() - startTime;
+        logger.warn(
+            "HDFS FileSystem connection reset completed - user: {}, label: {}, duration: {}",
+            user,
+            label,
+            org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+      } catch (Exception e) {
+        long duration = System.currentTimeMillis() - startTime;
+        logger.error(
+            "Failed to reset HDFS FileSystem connection - user: {}, label: {}, duration: {}",
+            user,
+            label,
+            org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+            e);
+        throw e;
       }
     }
   }
@@ -386,10 +433,31 @@ public class HDFSFileSystem extends FileSystem {
 
   @Override
   public void close() throws IOException {
-    if (null != fs) {
-      HDFSUtils.closeHDFSFIleSystem(fs, user);
-    } else {
-      logger.warn("FS was null, cannot close.");
+    long startTime = System.currentTimeMillis();
+    logger.info("Closing HDFSFileSystem - user: {}, label: {}", user, label);
+
+    try {
+      if (null != fs) {
+        HDFSUtils.closeHDFSFIleSystem(fs, user);
+      } else {
+        logger.warn("FS was null, cannot close.");
+      }
+
+      long duration = System.currentTimeMillis() - startTime;
+      logger.info(
+          "HDFSFileSystem closed successfully - user: {}, label: {}, duration: {}",
+          user,
+          label,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      logger.error(
+          "Failed to close HDFSFileSystem - user: {}, label: {}, duration: {}",
+          user,
+          label,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
     }
   }
 

--- a/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-computation-engineconn/src/main/scala/org/apache/linkis/engineconn/computation/executor/service/TaskExecutionServiceImpl.scala
@@ -541,7 +541,12 @@ class TaskExecutionServiceImpl
   override def dealRequestTaskStatus(requestTaskStatus: RequestTaskStatus): ResponseTaskStatus = {
     val task = getTaskByTaskId(requestTaskStatus.execId)
     if (null != task) {
-      ResponseTaskStatus(task.getTaskId, task.getStatus)
+      LoggerUtils.setJobIdMDC(task.getTaskId)
+      try {
+        ResponseTaskStatus(task.getTaskId, task.getStatus)
+      } finally {
+        LoggerUtils.removeJobIdMDC()
+      }
     } else {
       val msg =
         "Task null! requestTaskStatus: " + ComputationEngineUtils.GSON.toJson(requestTaskStatus)
@@ -552,18 +557,33 @@ class TaskExecutionServiceImpl
 
   @Receiver
   override def dealRequestTaskPause(requestTaskPause: RequestTaskPause): Unit = {
-    logger.info(s"Pause is Not supported for task : " + requestTaskPause.execId)
+    LoggerUtils.setJobIdMDC(requestTaskPause.execId)
+    try {
+      logger.info(s"Pause is Not supported for task : " + requestTaskPause.execId)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
   }
 
   @Receiver
   override def dealRequestTaskKill(requestTaskKill: RequestTaskKill): Unit = {
-    logger.warn(s"Requested to kill task : ${requestTaskKill.execId}")
-    killTask(requestTaskKill.execId)
+    LoggerUtils.setJobIdMDC(requestTaskKill.execId)
+    try {
+      logger.warn(s"Requested to kill task : ${requestTaskKill.execId}")
+      killTask(requestTaskKill.execId)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
   }
 
   @Receiver
   override def dealRequestTaskResume(requestTaskResume: RequestTaskResume): Unit = {
-    logger.info(s"Resume is Not support for task : " + requestTaskResume.execId)
+    LoggerUtils.setJobIdMDC(requestTaskResume.execId)
+    try {
+      logger.info(s"Resume is Not support for task : " + requestTaskResume.execId)
+    } finally {
+      LoggerUtils.removeJobIdMDC()
+    }
   }
 
   override def onEvent(event: EngineConnSyncEvent): Unit = event match {

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/restful/ECResourceInfoRestfulApi.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/restful/ECResourceInfoRestfulApi.java
@@ -19,6 +19,7 @@ package org.apache.linkis.manager.am.restful;
 
 import org.apache.linkis.common.conf.Configuration;
 import org.apache.linkis.common.utils.JsonUtils;
+import org.apache.linkis.common.utils.TokenSensitiveUtils;
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants;
 import org.apache.linkis.manager.am.exception.AMErrorException;
 import org.apache.linkis.manager.am.service.ECResourceInfoService;
@@ -203,7 +204,8 @@ public class ECResourceInfoRestfulApi {
     // check special admin token
     if (StringUtils.isNotBlank(token)) {
       if (!Configuration.isAdminToken(token)) {
-        logger.warn("Token:{} has no permission to query ecList.", token);
+        logger.warn(
+            "Token:{} has no permission to query ecList.", TokenSensitiveUtils.maskToken(token));
         return Message.error("Token:" + token + " has no permission to query ecList.");
       }
     } else if (!Configuration.isAdmin(username)) {

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/restful/EngineRestfulApi.java
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/java/org/apache/linkis/manager/am/restful/EngineRestfulApi.java
@@ -22,6 +22,7 @@ import org.apache.linkis.common.conf.Configuration;
 import org.apache.linkis.common.exception.LinkisRetryException;
 import org.apache.linkis.common.utils.ByteTimeUtils;
 import org.apache.linkis.common.utils.JsonUtils;
+import org.apache.linkis.common.utils.TokenSensitiveUtils;
 import org.apache.linkis.governance.common.conf.GovernanceCommonConf;
 import org.apache.linkis.governance.common.constant.ec.ECConstants;
 import org.apache.linkis.governance.common.utils.JobUtils;
@@ -454,7 +455,6 @@ public class EngineRestfulApi {
     for (Map<String, String> engineParam : param) {
       String moduleName = engineParam.get("applicationName");
       String engineInstance = engineParam.get("engineInstance");
-      logger.info("try to kill engine with engineInstance:{}", engineInstance);
       EngineStopRequest stopEngineRequest =
           new EngineStopRequest(ServiceInstance.apply(moduleName, engineInstance), userName);
       engineStopService.stopEngine(stopEngineRequest, sender);
@@ -478,8 +478,9 @@ public class EngineRestfulApi {
     // check special token
     if (StringUtils.isNotBlank(token)) {
       if (!Configuration.isAdminToken(token)) {
-        logger.warn("Token {} has no permission to asyn kill engines.", token);
-        return Message.error("Token:" + token + " has no permission to asyn kill engines.");
+        String maskedToken = TokenSensitiveUtils.maskToken(token);
+        logger.warn("Token {} has no permission to asyn kill engines.", maskedToken);
+        return Message.error("Token:" + maskedToken + " has no permission to asyn kill engines.");
       }
     } else if (!Configuration.isAdmin(username)) {
       logger.warn("User {} has no permission to asyn kill engines.", username);

--- a/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/DefaultEngineStopService.scala
+++ b/linkis-computation-governance/linkis-manager/linkis-application-manager/src/main/scala/org/apache/linkis/manager/am/service/engine/DefaultEngineStopService.scala
@@ -94,9 +94,7 @@ class DefaultEngineStopService extends AbstractEngineService with EngineStopServ
     engineStopRequest.getServiceInstance.setApplicationName(
       GovernanceCommonConf.ENGINE_CONN_SPRING_NAME.getValue
     )
-    logger.info(
-      s" user ${engineStopRequest.getUser} prepare to stop engine ${engineStopRequest.getServiceInstance}"
-    )
+
     val node = getEngineNodeManager.getEngineNode(engineStopRequest.getServiceInstance)
     if (null == node) {
       logger.info(s" engineConn does not exist in db: $engineStopRequest ")
@@ -106,6 +104,10 @@ class DefaultEngineStopService extends AbstractEngineService with EngineStopServ
     val labels = nodeLabelService.getNodeLabels(engineStopRequest.getServiceInstance)
     node.setLabels(labels)
 
+    logger.info(
+      s"try to kill engine with engineInstance: ${engineStopRequest.getServiceInstance},user:${engineStopRequest.getUser},engineType:${LabelUtil
+        .getEngineType(labels)}"
+    )
     // 1. request em to kill ec
     logger.info(s"Start to kill engine invoke enginePointer ${node.getServiceInstance}")
     Utils.tryAndErrorMsg {

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/InsertOperation.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/InsertOperation.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl;
 
+import org.apache.linkis.common.utils.CodeUtils;
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.AbstractJobOperation;
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.result.ColumnInfo;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.linkis.manager.label.entity.engine.EngineType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,7 +90,7 @@ public class InsertOperation extends AbstractJobOperation {
     try {
       tableResult = executionContext.wrapClassLoader(() -> tableEnv.executeSql(statement));
     } catch (Exception t) {
-      LOG.error(String.format("Invalid SQL query, sql is: %s.", statement), t);
+      LOG.error(String.format("Invalid SQL query, sql is: %s.", CodeUtils.maskCode(statement, EngineType.FLINK().toString())), t);
       // catch everything such that the statement does not crash the executor
       throw new SqlExecutionException(INVALID_SQL_STATEMENT.getErrorDesc(), t);
     }

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/SelectOperation.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/sql/operation/impl/SelectOperation.java
@@ -17,6 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.flink.client.sql.operation.impl;
 
+import org.apache.linkis.common.utils.CodeUtils;
 import org.apache.linkis.engineconnplugin.flink.client.context.ExecutionContext;
 import org.apache.linkis.engineconnplugin.flink.client.result.AbstractResult;
 import org.apache.linkis.engineconnplugin.flink.client.result.BatchResult;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.apache.linkis.manager.label.entity.engine.EngineType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -180,7 +182,7 @@ public class SelectOperation extends AbstractJobOperation {
       // the result needs to be closed as long as
       // it not stored in the result store
       result.close();
-      LOG.error(String.format("Invalid SQL query, sql is %s.", query), t);
+      LOG.error(String.format("Invalid SQL query, sql is %s.", CodeUtils.maskCode(query, EngineType.FLINK().toString())), t);
       // catch everything such that the query does not crash the executor
       throw new SqlExecutionException(INVALID_SQL_QUERY.getErrorDesc(), t);
     } finally {

--- a/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/utils/YarnConfLoader.java
+++ b/linkis-engineconn-plugins/flink/src/main/java/org/apache/linkis/engineconnplugin/flink/client/utils/YarnConfLoader.java
@@ -24,8 +24,16 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class YarnConfLoader {
+  private static final Logger LOG = LoggerFactory.getLogger(YarnConfLoader.class);
+
   public static YarnConfiguration getYarnConf(String yarnConfDir) {
+    long startTime = System.currentTimeMillis();
+    LOG.info("Loading Yarn configuration - yarnConfDir: {}", yarnConfDir);
+
     YarnConfiguration yarnConf = new YarnConfiguration();
     try {
       File dir = new File(yarnConfDir);
@@ -40,15 +48,35 @@ public class YarnConfLoader {
                       return false;
                     });
         if (xmlFileList != null) {
+          LOG.info("Found {} XML configuration files in {}", xmlFileList.length, yarnConfDir);
           for (File xmlFile : xmlFileList) {
+            LOG.debug("Adding Yarn configuration file: {}", xmlFile.getName());
             yarnConf.addResource(xmlFile.toURI().toURL());
           }
+        } else {
+          LOG.warn("No XML configuration files found in {}", yarnConfDir);
         }
+      } else {
+        LOG.warn(
+            "Yarn configuration directory does not exist or is not a directory: {}", yarnConfDir);
       }
     } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to load Yarn configuration - yarnConfDir: {}, duration: {}",
+          yarnConfDir,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
       throw new RuntimeException(e);
     }
+
     haYarnConf(yarnConf);
+
+    long duration = System.currentTimeMillis() - startTime;
+    LOG.info(
+        "Yarn configuration loaded successfully - yarnConfDir: {}, duration: {}",
+        yarnConfDir,
+        org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
     return yarnConf;
   }
 

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkCodeOnceExecutor.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/executor/FlinkCodeOnceExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.flink.executor
 
-import org.apache.linkis.common.utils.{ByteTimeUtils, Utils, VariableUtils}
+import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Utils, VariableUtils}
 import org.apache.linkis.engineconn.once.executor.OnceExecutorExecutionContext
 import org.apache.linkis.engineconnplugin.flink.client.deployment.YarnPerJobClusterDescriptorAdapter
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.OperationFactory
@@ -30,6 +30,7 @@ import org.apache.linkis.engineconnplugin.flink.exception.{
   SqlParseException
 }
 import org.apache.linkis.governance.common.paser.{CodeParserFactory, CodeType}
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.protocol.constants.TaskConstant
 import org.apache.linkis.scheduler.executer.ErrorExecuteResponse
 
@@ -64,14 +65,17 @@ class FlinkCodeOnceExecutor(
         if (StringUtils.isBlank(codes)) {
           throw new FlinkInitFailedException(SQL_CODE_EMPTY.getErrorDesc)
         }
-        logger.info(s"Ready to submit flink application, sql is: $codes.")
+        logger.info(s"Ready to submit flink application, sql is: ${CodeUtils
+          .maskCode(codes, EngineType.FLINK.toString() + "-SQL")}.")
         val variableMap =
           if (onceExecutorExecutionContext.getOnceExecutorContent.getVariableMap != null) {
             onceExecutorExecutionContext.getOnceExecutorContent.getVariableMap
               .asInstanceOf[util.Map[String, Any]]
           } else new util.HashMap[String, Any]
         codes = VariableUtils.replace(codes, variableMap)
-        logger.info(s"After variable replace, sql is: $codes.")
+        logger.info(
+          s"After variable replace, sql is: ${CodeUtils.maskCode(codes, EngineType.FLINK.toString() + "-SQL")}."
+        )
       case runType =>
         // Now, only support sql code.
         throw new FlinkInitFailedException(
@@ -110,7 +114,7 @@ class FlinkCodeOnceExecutor(
   protected def runCode(code: String): Unit = {
     if (isClosed) return
     val trimmedCode = StringUtils.trim(code)
-    logger.info(s"$getId >> " + trimmedCode)
+    logger.info(s"$getId >> " + CodeUtils.maskCode(trimmedCode, EngineType.FLINK.toString()))
     val startTime = System.currentTimeMillis
     val callOpt = SqlCommandParser.getSqlCommandParser.parse(code.trim, true)
     if (!callOpt.isPresent) {

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/ql/impl/CreateTableAsSelectGrammar.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/ql/impl/CreateTableAsSelectGrammar.scala
@@ -17,8 +17,10 @@
 
 package org.apache.linkis.engineconnplugin.flink.ql.impl
 
+import org.apache.linkis.common.utils.CodeUtils
 import org.apache.linkis.common.utils.Logging
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.OperationUtil
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.engineconnplugin.flink.client.sql.operation.result.ResultSet
 import org.apache.linkis.engineconnplugin.flink.context.FlinkEngineConnContext
 import org.apache.linkis.engineconnplugin.flink.ql.Grammar
@@ -41,7 +43,7 @@ class CreateTableAsSelectGrammar(context: FlinkEngineConnContext, sql: String)
    */
   override def execute(): ResultSet = sql match {
     case CreateTableAsSelectGrammar.CREATE_TABLE_AS_SELECT_GRAMMAR(_, _, tableName, _, _, select) =>
-      logger.info(s"Ready to create a table $tableName, the sql is: $select.")
+      logger.info(s"Ready to create a table $tableName, the sql is: ${CodeUtils.maskCode(select, EngineType.FLINK.toString())}.")
       val function = new java.util.function.Function[TableEnvironmentInternal, Unit] {
         override def apply(t: TableEnvironmentInternal): Unit = {
           val table = t.sqlQuery(select)

--- a/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/util/YarnUtil.scala
+++ b/linkis-engineconn-plugins/flink/src/main/scala/org/apache/linkis/engineconnplugin/flink/util/YarnUtil.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineconnplugin.flink.util
 
 import org.apache.linkis.common.exception.ErrorException
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{ByteTimeUtils, Logging}
 import org.apache.linkis.engineconn.core.executor.ExecutorManager
 import org.apache.linkis.engineconn.executor.entity.YarnExecutor
 import org.apache.linkis.engineconnplugin.flink.config.FlinkEnvConfiguration
@@ -70,26 +70,55 @@ object YarnUtil extends Logging {
   }
 
   private def createYarnClient(): YarnClient = {
-    val yarnClient = YarnClient.createYarnClient()
-    val hadoopConf = getHadoopConf()
-    val yarnConfiguration = new YarnConfiguration(hadoopConf)
-    yarnClient.init(yarnConfiguration)
-    yarnClient.start()
-    yarnClient
+    val startTime = System.currentTimeMillis()
+    logger.info("Creating YarnClient")
+
+    try {
+      val yarnClient = YarnClient.createYarnClient()
+      val hadoopConf = getHadoopConf()
+      val yarnConfiguration = new YarnConfiguration(hadoopConf)
+      yarnClient.init(yarnConfiguration)
+      yarnClient.start()
+
+      val duration = ByteTimeUtils.msDurationToString(System.currentTimeMillis() - startTime)
+      logger.info(s"YarnClient created and started successfully - duration: $duration")
+      yarnClient
+    } catch {
+      case e: Exception =>
+        val duration = ByteTimeUtils.msDurationToString(System.currentTimeMillis() - startTime)
+        logger.error(s"Failed to create YarnClient - duration: $duration", e)
+        throw e
+    }
   }
 
   private def getHadoopConf(): Configuration = {
-    val conf = new Configuration()
-    var confRoot = FlinkEnvConfiguration.HADOOP_CONF_DIR.getValue
-    if (StringUtils.isBlank(confRoot)) {
-      throw new JobExecutionException("HADOOP_CONF_DIR or linkis.flink.hadoop.conf.dir not set!")
+    val startTime = System.currentTimeMillis()
+    logger.info("Loading Hadoop configuration for YarnClient")
+
+    try {
+      val conf = new Configuration()
+      var confRoot = FlinkEnvConfiguration.HADOOP_CONF_DIR.getValue
+      if (StringUtils.isBlank(confRoot)) {
+        throw new JobExecutionException("HADOOP_CONF_DIR or linkis.flink.hadoop.conf.dir not set!")
+      }
+      confRoot = confRoot + "/"
+      logger.info(s"Hadoop config directory: $confRoot")
+      conf.addResource(confRoot + HDFS_SITE)
+      conf.addResource(confRoot + CORE_SITE)
+      conf.addResource(confRoot + MAPRED_SITE)
+      conf.addResource(confRoot + YARN_SITE)
+
+      val duration = ByteTimeUtils.msDurationToString(System.currentTimeMillis() - startTime)
+      logger.info(
+        s"Hadoop configuration loaded successfully - confRoot: $confRoot, duration: $duration"
+      )
+      conf
+    } catch {
+      case e: Exception =>
+        val duration = ByteTimeUtils.msDurationToString(System.currentTimeMillis() - startTime)
+        logger.error(s"Failed to load Hadoop configuration - duration: $duration", e)
+        throw e
     }
-    confRoot = confRoot + "/"
-    conf.addResource(confRoot + HDFS_SITE)
-    conf.addResource(confRoot + CORE_SITE)
-    conf.addResource(confRoot + MAPRED_SITE)
-    conf.addResource(confRoot + YARN_SITE)
-    conf
   }
 
   def setClusterEntrypointInfoToConfig(

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConcurrentConnExecutor.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConcurrentConnExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineplugin.hive.executor
 
 import org.apache.linkis.common.exception.ErrorException
-import org.apache.linkis.common.utils.{ByteTimeUtils, Logging, Utils}
+import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
 import org.apache.linkis.engineconn.computation.executor.execute.{
   ConcurrentComputationExecutor,
@@ -27,6 +27,7 @@ import org.apache.linkis.engineconn.computation.executor.execute.{
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.executor.entity.{ConcurrentExecutor, ResourceFetchExecutor}
 import org.apache.linkis.engineplugin.hive.conf.{Counters, HiveEngineConfiguration}
+import org.apache.linkis.engineplugin.hive.conf.HiveEngineConfiguration.HIVE_TAG_USER_ENABLE
 import org.apache.linkis.engineplugin.hive.creation.HiveEngineConnFactory
 import org.apache.linkis.engineplugin.hive.cs.CSHiveHelper
 import org.apache.linkis.engineplugin.hive.errorcode.HiveErrorCodeSummary.COMPILE_HIVE_QUERY_ERROR
@@ -43,6 +44,7 @@ import org.apache.linkis.manager.common.entity.resource.{
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.scheduler.executer.{
   CompletedExecuteResponse,
@@ -134,13 +136,16 @@ class HiveEngineConcurrentConnExecutor(
       engineExecutorContext: EngineExecutionContext,
       code: String
   ): ExecuteResponse = {
-    LOG.info(s"HiveEngineConcurrentConnExecutor Ready to executeLine: $code")
+    LOG.info(s"HiveEngineConcurrentConnExecutor Ready to executeLine: ${CodeUtils
+      .maskCode(code, EngineType.HIVE.toString())}")
     val taskId: String = engineExecutorContext.getJobId.get
     CSHiveHelper.setContextIDInfoToHiveConf(engineExecutorContext, hiveConf)
 
     val realCode = code.trim()
 
-    LOG.info(s"hive client begins to run hql code:\n ${realCode.trim}")
+    LOG.info(
+      s"hive client begins to run hql code:\n ${CodeUtils.maskCode(realCode.trim, EngineType.HIVE.toString())}"
+    )
     val jobId = JobUtils.getJobIdFromMap(engineExecutorContext.getProperties)
     if (StringUtils.isNotBlank(jobId)) {
       LOG.info(s"set mapreduce.job.tags=LINKIS_$jobId")
@@ -224,11 +229,11 @@ class HiveEngineConcurrentConnExecutor(
             var compileRet = -1
             Utils.tryCatch {
               compileRet = driver.compile(realCode)
-              logger.info(
-                s"driver compile realCode : \n ${realCode} \n finished, status : ${compileRet}"
-              )
+              logger.info(s"driver compile realCode : \n ${CodeUtils
+                .maskCode(realCode, EngineType.HIVE.toString())} \n finished, status : ${compileRet}")
               if (0 != compileRet) {
-                logger.warn(s"compile realCode : \n ${realCode} \n error status : ${compileRet}")
+                logger.warn(s"compile realCode : \n ${CodeUtils
+                  .maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
                 throw HiveQueryFailedException(
                   COMPILE_HIVE_QUERY_ERROR.getErrorCode,
                   COMPILE_HIVE_QUERY_ERROR.getErrorDesc

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/executor/HiveEngineConnExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineplugin.hive.executor
 
 import org.apache.linkis.common.exception.ErrorException
-import org.apache.linkis.common.utils.{ByteTimeUtils, Logging, Utils}
+import org.apache.linkis.common.utils.{ByteTimeUtils, CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
 import org.apache.linkis.engineconn.computation.executor.execute.{
@@ -44,6 +44,7 @@ import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, Nod
 import org.apache.linkis.manager.common.protocol.resource.ResourceWithStatus
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.scheduler.executer.{
   ErrorExecuteResponse,
@@ -161,7 +162,9 @@ class HiveEngineConnExecutor(
     singleCodeCompleted.set(false)
     currentSqlProgress = 0.0f
     val realCode = code.trim()
-    LOG.info(s"hive client begins to run hql code:\n ${realCode.trim}")
+    LOG.info(
+      s"hive client begins to run hql code:\n ${CodeUtils.maskCode(realCode.trim, EngineType.HIVE.toString())}"
+    )
     val jobId = JobUtils.getJobIdFromMap(engineExecutorContext.getProperties)
 
     if (StringUtils.isNotBlank(jobId)) {
@@ -257,11 +260,11 @@ class HiveEngineConnExecutor(
             var compileRet = -1
             Utils.tryCatch {
               compileRet = driver.compile(realCode)
-              logger.info(
-                s"driver compile realCode : \n ${realCode} \n finished, status : ${compileRet}"
-              )
+              logger.info(s"driver compile realCode : \n ${CodeUtils
+                .maskCode(realCode, EngineType.HIVE.toString())} \n finished, status : ${compileRet}")
               if (0 != compileRet) {
-                logger.warn(s"compile realCode : \n ${realCode} \n error status : ${compileRet}")
+                logger.warn(s"compile realCode : \n ${CodeUtils
+                  .maskCode(realCode, EngineType.HIVE.toString())} \n error status : ${compileRet}")
                 throw HiveQueryFailedException(
                   COMPILE_HIVE_QUERY_ERROR.getErrorCode,
                   COMPILE_HIVE_QUERY_ERROR.getErrorDesc
@@ -692,7 +695,11 @@ class HiveEngineConnExecutor(
             .getOrElse(Map.empty)
           hiveTmpConf.foreach { case (key, value) =>
             currentProps.get(key).filter(_ != value).foreach { userValue =>
-              logger.info(s"Resetting configuration key: $key,value: $value cover $userValue")
+              if (key.equals("hive.query.string") || key.equals("mapreduce.workflow.name")) {
+                // 会打印用户sql，涉及敏感信息不打印
+              } else {
+                logger.info(s"Resetting configuration key: $key,value: $value cover $userValue")
+              }
               sessionConf.set(key, value)
             }
           }

--- a/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/hook/HiveAddJarsEngineHook.scala
+++ b/linkis-engineconn-plugins/hive/src/main/scala/org/apache/linkis/engineplugin/hive/hook/HiveAddJarsEngineHook.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineplugin.hive.hook
 
 import org.apache.linkis.common.conf.CommonVars
-import org.apache.linkis.common.utils.{Logging, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.common.creation.EngineCreationContext
 import org.apache.linkis.engineconn.common.engineconn.EngineConn
 import org.apache.linkis.engineconn.common.hook.EngineConnHook
@@ -74,7 +74,7 @@ class HiveAddJarsEngineHook extends EngineConnHook with Logging {
       jars.split(",") foreach { jar =>
         try {
           val sql = addSql + jar
-          logger.info("begin to run hive sql {}", sql)
+          logger.info("begin to run hive sql {}", CodeUtils.maskCode(sql))
           ExecutorManager.getInstance.getExecutorByLabels(labels) match {
             case executor: HiveEngineConnExecutor =>
               executor.executeLine(new EngineExecutionContext(executor), sql)

--- a/linkis-engineconn-plugins/hive/src/test/scala/org/apache/linkis/engineplugin/hive/executor/HiveYarnTagUsernameTest.scala
+++ b/linkis-engineconn-plugins/hive/src/test/scala/org/apache/linkis/engineplugin/hive/executor/HiveYarnTagUsernameTest.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.engineplugin.hive.executor
+
+import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
+import org.apache.linkis.governance.common.constant.job.JobRequestConstants
+import org.apache.linkis.governance.common.utils.JobUtils
+
+import org.apache.commons.lang3.StringUtils
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito._
+
+/**
+ * Test class for YARN tag username enhancement feature. Tests the logic of adding username to YARN
+ * job tags.
+ */
+class HiveYarnTagUsernameTest {
+
+  /**
+   * Test case TC001: Normal username + no jobTags Expected: LINKIS_123,USER_zhangsan
+   */
+  @Test
+  def testNormalUsernameNoJobTags(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "zhangsan")
+    properties.put(JobRequestConstants.JOB_ID, "123")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    assertEquals("LINKIS_123,USER_zhangsan", tags)
+  }
+
+  /**
+   * Test case TC002: Normal username + has jobTags Expected: LINKIS_123,EMR,USER_zhangsan
+   */
+  @Test
+  def testNormalUsernameWithJobTags(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "zhangsan")
+    properties.put(JobRequestConstants.JOB_ID, "123")
+    properties.put(JobRequestConstants.JOB_SOURCE_TAGS, "EMR")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    assertEquals("LINKIS_123,EMR,USER_zhangsan", tags)
+  }
+
+  /**
+   * Test case TC003: Empty username Expected: LINKIS_123 (without USER tag)
+   */
+  @Test
+  def testEmptyUsername(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "")
+    properties.put(JobRequestConstants.JOB_ID, "123")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    assertEquals("LINKIS_123", tags)
+  }
+
+  /**
+   * Test case TC004: Null username Expected: LINKIS_123 (without USER tag)
+   */
+  @Test
+  def testNullUsername(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put(JobRequestConstants.JOB_ID, "123")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    assertEquals("LINKIS_123", tags)
+  }
+
+  /**
+   * Test case TC005: Empty jobId Expected: No tags (return null)
+   */
+  @Test
+  def testEmptyJobId(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "zhangsan")
+    properties.put(JobRequestConstants.JOB_ID, "")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+
+    // When jobId is blank, tags should be null
+    if (StringUtils.isNotBlank(jobId)) {
+      fail("Should not reach here when jobId is blank")
+    } else {
+      // No tags should be set
+      assertNull(null)
+    }
+  }
+
+  /**
+   * Test case TC006: Username with special characters Expected: LINKIS_123,USER_user@example.com
+   */
+  @Test
+  def testUsernameWithSpecialCharacters(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "user@example.com")
+    properties.put(JobRequestConstants.JOB_ID, "123")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    assertEquals("LINKIS_123,USER_user@example.com", tags)
+  }
+
+  /**
+   * Test case TC007: Username with underscore Expected: LINKIS_123,USER_user_name
+   */
+  @Test
+  def testUsernameWithUnderscore(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "user_name")
+    properties.put(JobRequestConstants.JOB_ID, "123")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    assertEquals("LINKIS_123,USER_user_name", tags)
+  }
+
+  /**
+   * Test case TC008: Null properties Expected: execUser should be null
+   */
+  @Test
+  def testNullProperties(): Unit = {
+    val execUser = extractExecUser(null)
+    assertNull(execUser)
+  }
+
+  /**
+   * Test case TC009: execUser is not a String type Expected: execUser should be null
+   */
+  @Test
+  def testInvalidExecUserType(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", 123.asInstanceOf[Object])
+
+    val execUser = extractExecUser(properties)
+    assertNull(execUser)
+  }
+
+  /**
+   * Test case TC010: jobTags with non-ASCII characters Expected: LINKIS_123,USER_zhangsan (jobTags
+   * ignored)
+   */
+  @Test
+  def testNonAsciiJobTags(): Unit = {
+    val properties = new util.HashMap[String, Object]()
+    properties.put("execUser", "zhangsan")
+    properties.put(JobRequestConstants.JOB_ID, "123")
+    properties.put(JobRequestConstants.JOB_SOURCE_TAGS, "中文标签")
+
+    val execUser = extractExecUser(properties)
+    val jobId = JobUtils.getJobIdFromMap(properties)
+    val jobTags = JobUtils.getJobSourceTagsFromObjectMap(properties)
+
+    val tags = buildTags(jobId, jobTags, execUser)
+
+    // Non-ASCII jobTags should be ignored
+    assertEquals("LINKIS_123,USER_zhangsan", tags)
+  }
+
+  /**
+   * Helper method to simulate the execUser extraction logic
+   */
+  private def extractExecUser(properties: util.Map[String, Object]): String = {
+    if (properties != null) {
+      properties.get("execUser") match {
+        case user: String => user
+        case _ => null
+      }
+    } else null
+  }
+
+  /**
+   * Helper method to simulate the tags building logic
+   */
+  private def buildTags(jobId: String, jobTags: String, execUser: String): String = {
+    if (StringUtils.isAsciiPrintable(jobTags)) {
+      if (StringUtils.isNotBlank(execUser)) {
+        s"LINKIS_$jobId,$jobTags,USER_$execUser"
+      } else {
+        s"LINKIS_$jobId,$jobTags"
+      }
+    } else {
+      if (StringUtils.isNotBlank(execUser)) {
+        s"LINKIS_$jobId,USER_$execUser"
+      } else {
+        s"LINKIS_$jobId"
+      }
+    }
+  }
+
+}

--- a/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/executor/JDBCEngineConnExecutor.scala
@@ -19,64 +19,40 @@ package org.apache.linkis.manager.engineplugin.jdbc.executor
 
 import org.apache.linkis.common.conf.Configuration
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.{OverloadUtils, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, OverloadUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.entity.EngineConnTask
-import org.apache.linkis.engineconn.computation.executor.execute.{
-  ConcurrentComputationExecutor,
-  EngineExecutionContext
-}
+import org.apache.linkis.engineconn.computation.executor.execute.{ConcurrentComputationExecutor, EngineExecutionContext}
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.governance.common.paser.SQLCodeParser
-import org.apache.linkis.governance.common.protocol.conf.{
-  RequestQueryEngineConfig,
-  ResponseQueryConfig
-}
-import org.apache.linkis.manager.common.entity.resource.{
-  CommonNodeResource,
-  LoadResource,
-  NodeResource
-}
+import org.apache.linkis.governance.common.protocol.conf.{RequestQueryEngineConfig, ResponseQueryConfig}
+import org.apache.linkis.manager.common.entity.resource.{CommonNodeResource, LoadResource, NodeResource}
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.engineplugin.jdbc.ConnectionManager
 import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration
-import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration.{
-  NOT_SUPPORT_LIMIT_DBS,
-  SUPPORT_CONN_PARAM_EXECUTE_ENABLE
-}
+import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration.{NOT_SUPPORT_LIMIT_DBS, SUPPORT_CONN_PARAM_EXECUTE_ENABLE}
 import org.apache.linkis.manager.engineplugin.jdbc.constant.JDBCEngineConnConstant
 import org.apache.linkis.manager.engineplugin.jdbc.errorcode.JDBCErrorCodeSummary.JDBC_GET_DATASOURCEINFO_ERROR
-import org.apache.linkis.manager.engineplugin.jdbc.exception.{
-  JDBCGetDatasourceInfoException,
-  JDBCParamsIllegalException
-}
+import org.apache.linkis.manager.engineplugin.jdbc.exception.{JDBCGetDatasourceInfoException, JDBCParamsIllegalException}
 import org.apache.linkis.manager.engineplugin.jdbc.monitor.ProgressMonitor
 import org.apache.linkis.manager.label.entity.Label
-import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import org.apache.linkis.manager.label.entity.engine.{EngineType, EngineTypeLabel, UserCreatorLabel}
 import org.apache.linkis.protocol.CacheableProtocol
 import org.apache.linkis.protocol.constants.TaskConstant
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.rpc.{RPCMapCache, Sender}
-import org.apache.linkis.scheduler.executer.{
-  AliasOutputExecuteResponse,
-  ErrorExecuteResponse,
-  ExecuteResponse,
-  SuccessExecuteResponse
-}
+import org.apache.linkis.scheduler.executer.{AliasOutputExecuteResponse, ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 import org.apache.linkis.storage.domain.{Column, DataType}
 import org.apache.linkis.storage.resultset.ResultSetFactory
 import org.apache.linkis.storage.resultset.table.{TableMetaData, TableRecord}
-
 import org.apache.commons.collections.MapUtils
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.springframework.util.CollectionUtils
 
 import java.sql.{Connection, ResultSet, Statement}
 import java.util
 import java.util.concurrent.ConcurrentHashMap
-
 import scala.collection.mutable.ArrayBuffer
 
 class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
@@ -236,7 +212,7 @@ class JDBCEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
       }
     } catch {
       case e: Throwable =>
-        logger.error(s"Cannot run $code", e)
+        logger.error(s"Cannot run ${CodeUtils.maskCode(code, EngineType.JDBC.toString())}", e)
         // 推送堆栈信息到前端
         val errorStr = ExceptionUtils.getStackTrace(e)
         engineExecutorContext.appendStdout(

--- a/linkis-engineconn-plugins/nebula/src/main/java/org/apache/linkis/engineplugin/nebula/executor/NebulaEngineConnExecutor.java
+++ b/linkis-engineconn-plugins/nebula/src/main/java/org/apache/linkis/engineplugin/nebula/executor/NebulaEngineConnExecutor.java
@@ -21,6 +21,7 @@ import org.apache.linkis.common.exception.ErrorException;
 import org.apache.linkis.common.io.resultset.ResultSetWriter;
 import org.apache.linkis.common.log.LogUtils;
 import org.apache.linkis.common.utils.AESUtils;
+import org.apache.linkis.common.utils.CodeUtils;
 import org.apache.linkis.common.utils.OverloadUtils;
 import org.apache.linkis.engineconn.common.conf.EngineConnConf;
 import org.apache.linkis.engineconn.common.conf.EngineConnConstant;
@@ -39,6 +40,7 @@ import org.apache.linkis.manager.common.entity.resource.LoadResource;
 import org.apache.linkis.manager.common.entity.resource.NodeResource;
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils;
 import org.apache.linkis.manager.label.entity.Label;
+import org.apache.linkis.manager.label.entity.engine.EngineType;
 import org.apache.linkis.manager.label.entity.engine.EngineTypeLabel;
 import org.apache.linkis.manager.label.entity.engine.UserCreatorLabel;
 import org.apache.linkis.protocol.engine.JobProgressInfo;
@@ -135,7 +137,9 @@ public class NebulaEngineConnExecutor extends ConcurrentComputationExecutor {
     } else {
       realCode = code.trim();
     }
-    logger.info("Nebula client begins to run ngql code:\n {}", realCode);
+    logger.info(
+        "Nebula client begins to run ngql code: {}",
+        CodeUtils.maskCode(realCode, EngineType.NEBULA().toString()));
 
     String taskId = engineExecutorContext.getJobId().get();
     NebulaPool nebulaPool = nebulaPoolCache.getIfPresent(taskId);

--- a/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/python/src/main/scala/org/apache/linkis/manager/engineplugin/python/executor/PythonEngineConnExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.manager.engineplugin.python.executor
 
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.execute.{
   ComputationExecutor,
   EngineExecutionContext
@@ -110,7 +110,7 @@ class PythonEngineConnExecutor(id: Int, pythonSession: PythonSession, outputPrin
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.debug("newcode is " + newcode)
+    logger.debug("newcode is " + CodeUtils.maskCode(newcode, "python"))
     executeLine(engineExecutionContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelFlinkOnceCodeExecutor.scala
+++ b/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelFlinkOnceCodeExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.seatunnel.executor
 
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf.ENGINE_CONN_LOCAL_PATH_PWD_KEY
 import org.apache.linkis.engineconn.computation.executor.utlis.ComputationEngineUtils.GSON
 import org.apache.linkis.engineconn.core.EngineConnObject
@@ -81,7 +81,7 @@ class SeatunnelFlinkOnceCodeExecutor(
       .asInstanceOf[util.Map[String, String]]
     future = Utils.defaultScheduler.submit(new Runnable {
       override def run(): Unit = {
-        logger.info("Try to execute codes." + code)
+        logger.info("Try to execute codes." + CodeUtils.maskCode(code, "seatunnel"))
         if (runCode(code) != 0) {
           isFailed = true
           setResponse(

--- a/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelSparkOnceCodeExecutor.scala
+++ b/linkis-engineconn-plugins/seatunnel/src/main/scala/org/apache/linkis/engineconnplugin/seatunnel/executor/SeatunnelSparkOnceCodeExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.engineconnplugin.seatunnel.executor
 
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.common.conf.EngineConnConf.ENGINE_CONN_LOCAL_PATH_PWD_KEY
 import org.apache.linkis.engineconn.core.EngineConnObject
 import org.apache.linkis.engineconn.once.executor.{
@@ -70,7 +70,7 @@ class SeatunnelSparkOnceCodeExecutor(
       .asInstanceOf[util.Map[String, String]]
     future = Utils.defaultScheduler.submit(new Runnable {
       override def run(): Unit = {
-        logger.info("Try to execute codes." + code)
+        logger.info("Try to execute codes." + CodeUtils.maskCode(code, "seatunnel"))
         if (runCode(code) != 0) {
           isFailed = true
           setResponse(

--- a/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnConcurrentExecutor.scala
+++ b/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnConcurrentExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.manager.engineplugin.shell.executor
 
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.{Logging, OverloadUtils, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, Logging, OverloadUtils, Utils}
 import org.apache.linkis.engineconn.acessible.executor.listener.event.TaskLogUpdateEvent
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
 import org.apache.linkis.engineconn.computation.executor.execute.{
@@ -85,7 +85,7 @@ class ShellEngineConnConcurrentExecutor(id: Int)
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.debug("newcode is " + newcode)
+    logger.debug("newcode is " + CodeUtils.maskCode(newcode, "shell"))
     executeLine(engineExecutionContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/shell/src/main/scala/org/apache/linkis/manager/engineplugin/shell/executor/ShellEngineConnExecutor.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.manager.engineplugin.shell.executor
 
-import org.apache.linkis.common.utils.{Logging, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, Logging, Utils}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
 import org.apache.linkis.engineconn.computation.executor.execute.{
   ComputationExecutor,
@@ -76,7 +76,7 @@ class ShellEngineConnExecutor(id: Int) extends ComputationExecutor with Logging 
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.debug("newcode is " + newcode)
+    logger.debug("newcode is " + CodeUtils.maskCode(newcode, "shell"))
     executeLine(engineExecutionContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/resources/log4j2.xml
+++ b/linkis-engineconn-plugins/spark/src/main/resources/log4j2.xml
@@ -87,6 +87,12 @@
         <logger name="org.apache.spark.deploy.yarn.Client" level="INFO" additivity="true">
             <appender-ref ref="YarnAppIdOutputFile"/>
         </logger>
+        <!-- Filter Spark FutureWarning messages (e.g., HiveContext is deprecated) -->
+        <logger name="org.apache.linkis.engineplugin.spark.executor.SparkPythonExecutor" level="INFO" additivity="false">
+            <appender-ref ref="RollingFile">
+                <RegexFilter regex=".*FutureWarning.*" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </appender-ref>
+        </logger>
         <logger name="org.apache.linkis.engineconn.computation.executor.hook" level="INFO" additivity="true">
             <appender-ref ref="UDFOutputFile"/>
         </logger>

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/JdbcSink.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/sink/JdbcSink.scala
@@ -18,16 +18,15 @@
 package org.apache.linkis.engineplugin.spark.datacalc.sink
 
 import org.apache.linkis.common.utils.ClassUtils.getFieldVal
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcSink
-
 import org.apache.commons.lang3.StringUtils
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 import java.sql.{Connection, DriverManager}
-
 import scala.collection.JavaConverters._
 
 class JdbcSink extends DataCalcSink[JdbcSinkConfig] with Logging {
@@ -64,7 +63,7 @@ class JdbcSink extends DataCalcSink[JdbcSinkConfig] with Logging {
             DriverManager.getConnection(config.getUrl, config.getUser, config.getPassword)
           try {
             config.getPreQueries.asScala.foreach(query => {
-              logger.info(s"Execute pre query: $query")
+              logger.info(s"Execute pre query: ${CodeUtils.maskCode(query, EngineType.SPARK.toString())}")
               execute(conn, jdbcOptions, query)
             })
           } catch {
@@ -86,7 +85,7 @@ class JdbcSink extends DataCalcSink[JdbcSinkConfig] with Logging {
   }
 
   private def execute(conn: Connection, jdbcOptions: JDBCOptions, query: String): Unit = {
-    logger.info("Execute query: {}", query)
+    logger.info("Execute query: {}", CodeUtils.maskCode(query, EngineType.SPARK.toString()))
     val statement = conn.prepareStatement(query)
     try {
       // `queryTimeout` was added after spark2.4.0, more details please check SPARK-23856

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/transform/SqlTransform.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/datacalc/transform/SqlTransform.scala
@@ -17,15 +17,15 @@
 
 package org.apache.linkis.engineplugin.spark.datacalc.transform
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineplugin.spark.datacalc.api.DataCalcTransform
-
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 
 class SqlTransform extends DataCalcTransform[SqlTransformConfig] with Logging {
 
   override def process(spark: SparkSession, ds: Dataset[Row]): Dataset[Row] = {
-    logger.info(s"Load data from query: ${config.getSql}")
+    logger.info(s"Load data from query: ${CodeUtils.maskCode(config.getSql, EngineType.SPARK.toString())}")
     spark.sql(config.getSql)
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkDataCalcExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkDataCalcExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineplugin.spark.executor
 
 import org.apache.linkis.common.exception.FatalException
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
 import org.apache.linkis.engineconn.core.executor.ExecutorManager
 import org.apache.linkis.engineplugin.spark.common.{Kind, SparkDataCalc}
@@ -27,6 +27,7 @@ import org.apache.linkis.engineplugin.spark.datacalc.model.{DataCalcArrayData, D
 import org.apache.linkis.engineplugin.spark.entity.SparkEngineSession
 import org.apache.linkis.engineplugin.spark.utils.EngineUtils
 import org.apache.linkis.governance.common.paser.EmptyCodeParser
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.scheduler.executer.{
   CompletedExecuteResponse,
   ErrorExecuteResponse,
@@ -53,7 +54,10 @@ class SparkDataCalcExecutor(sparkEngineSession: SparkEngineSession, id: Long)
       context: EngineExecutionContext,
       jobGroup: String
   ): ExecuteResponse = {
-    logger.info("DataCalcExecutor run query: " + code)
+    logger.info(
+      "DataCalcExecutor run query: " + CodeUtils
+        .maskCode(code, EngineType.SPARK.toString() + "-DataCalc")
+    )
     context.appendStdout(s"${EngineUtils.getName} >> $code")
     Utils.tryCatch {
       val execType = context.getProperties.getOrDefault("exec-type", "array").toString

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkEngineConnExecutor.scala
@@ -19,7 +19,13 @@ package org.apache.linkis.engineplugin.spark.executor
 
 import org.apache.linkis.common.conf.Configuration
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.{ByteTimeUtils, CodeAndRunTypeUtils, Logging, Utils}
+import org.apache.linkis.common.utils.{
+  ByteTimeUtils,
+  CodeAndRunTypeUtils,
+  CodeUtils,
+  Logging,
+  Utils
+}
 import org.apache.linkis.engineconn.common.conf.{EngineConnConf, EngineConnConstant}
 import org.apache.linkis.engineconn.common.creation.EngineCreationContext
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
@@ -59,6 +65,7 @@ import org.apache.linkis.manager.label.conf.LabelCommonConfig
 import org.apache.linkis.manager.label.constant.LabelKeyConstant
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.manager.label.entity.engine.{CodeLanguageLabel, EngineType}
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.manager.label.utils.LabelUtil
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.scheduler.executer.ExecuteResponse
@@ -225,13 +232,19 @@ abstract class SparkEngineConnExecutor(val sc: SparkContext, id: Long)
         // with unit if set configuration with unit
         // if not set sc get will get the value of spark.yarn.executor.memoryOverhead such as 512(without unit)
         val memoryOverhead = sc.getConf.get("spark.executor.memoryOverhead", "1G")
-        val pythonVersion = SparkConfiguration.SPARK_PYTHON_VERSION.getValue(
-          EngineConnObject.getEngineCreationContext.getOptions
-        )
+        val engineCreationOptions = EngineConnObject.getEngineCreationContext.getOptions
+        val pythonVersion = if (engineCreationOptions != null) {
+          SparkConfiguration.SPARK_PYTHON_VERSION.getValue(engineCreationOptions)
+        } else {
+          SparkConfiguration.SPARK_PYTHON_VERSION.getValue
+        }
         var engineType = ""
         val labels = engineExecutorContext.getLabels
         if (labels.length > 0) {
-          engineType = LabelUtil.getEngineTypeLabel(labels.toList.asJava).getStringValue
+          val engineTypeLabel = LabelUtil.getEngineTypeLabel(labels.toList.asJava)
+          if (engineTypeLabel != null) {
+            engineType = engineTypeLabel.getStringValue
+          }
         }
         val sb = new StringBuilder
         sb.append(s"spark.executor.instances=$executorNum\n")
@@ -365,7 +378,7 @@ abstract class SparkEngineConnExecutor(val sc: SparkContext, id: Long)
       completedLine: String
   ): ExecuteResponse = {
     val newcode = completedLine + code
-    logger.info("newcode is " + newcode)
+    logger.info("newcode is " + CodeUtils.maskCode(newcode, EngineType.SPARK.toString()))
     executeLine(engineExecutorContext, newcode)
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkSqlExecutor.scala
@@ -17,7 +17,8 @@
 
 package org.apache.linkis.engineplugin.spark.executor
 
-import org.apache.linkis.common.utils.Utils
+import org.apache.linkis.common.io.FsPath
+import org.apache.linkis.common.utils.{CodeUtils, Utils}
 import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
 import org.apache.linkis.engineplugin.spark.common.{Kind, SparkSQL}
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
@@ -25,13 +26,9 @@ import org.apache.linkis.engineplugin.spark.entity.SparkEngineSession
 import org.apache.linkis.engineplugin.spark.utils.EngineUtils
 import org.apache.linkis.governance.common.constant.job.JobRequestConstants
 import org.apache.linkis.governance.common.paser.SQLCodeParser
-import org.apache.linkis.scheduler.executer.{
-  ErrorExecuteResponse,
-  ExecuteResponse,
-  SuccessExecuteResponse
-}
-
+import org.apache.linkis.scheduler.executer.{ErrorExecuteResponse, ExecuteResponse, SuccessExecuteResponse}
 import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.linkis.manager.label.entity.engine.EngineType
 
 import java.lang.reflect.InvocationTargetException
 
@@ -66,7 +63,9 @@ class SparkSqlExecutor(sparkEngineSession: SparkEngineSession, id: Long)
       sparkEngineSession.sqlContext.sql(s"use $defaultDB")
     }
 
-    logger.info("SQLExecutor run query: " + code)
+    logger.info(
+      "SQLExecutor run query: " + CodeUtils.maskCode(code, EngineType.SPARK.toString() + "-SQL")
+    )
     engineExecutionContext.appendStdout(s"${EngineUtils.getName} >> $code")
     val standInClassLoader = Thread.currentThread().getContextClassLoader
     try {

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/imexport/ExportData.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/imexport/ExportData.scala
@@ -17,9 +17,10 @@
 
 package org.apache.linkis.engineplugin.spark.imexport
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.imexport.util.BackGroundServiceUtils
+import org.apache.linkis.manager.label.entity.engine.EngineType
 
 import org.apache.spark.sql.SparkSession
 
@@ -113,7 +114,7 @@ object ExportData extends Logging {
     sql.append("select ").append(columns).append(" from ").append(s"$database.$tableName")
     if (isPartition) sql.append(" where ").append(s"$partition=$partitionValue")
     val sqlString = sql.toString()
-    logger.warn(s"export sql:$sqlString")
+    logger.warn(s"export sql:${CodeUtils.maskCode(sqlString, EngineType.SPARK.toString)}")
     sqlString
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPostExecutionHook.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/mdq/MDQPostExecutionHook.scala
@@ -17,14 +17,14 @@
 
 package org.apache.linkis.engineplugin.spark.mdq
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
 import org.apache.linkis.engineconn.computation.executor.execute.EngineExecutionContext
 import org.apache.linkis.engineplugin.spark.common.SparkKind
 import org.apache.linkis.engineplugin.spark.config.SparkConfiguration
 import org.apache.linkis.engineplugin.spark.extension.SparkPostExecutionHook
 import org.apache.linkis.governance.common.constant.CodeConstants
 import org.apache.linkis.governance.common.constant.job.TaskInfoConstants
-import org.apache.linkis.manager.label.entity.engine.CodeLanguageLabel
+import org.apache.linkis.manager.label.entity.engine.{CodeLanguageLabel, EngineType}
 import org.apache.linkis.protocol.mdq.{DDLCompleteResponse, DDLExecuteResponse}
 import org.apache.linkis.rpc.Sender
 import org.apache.linkis.scheduler.executer.{ExecuteResponse, SuccessExecuteResponse}
@@ -73,10 +73,16 @@ class MDQPostExecutionHook extends SparkPostExecutionHook with Logging {
         sender.ask(DDLExecuteResponse(true, code, StorageUtils.getJvmUser)) match {
           case DDLCompleteResponse(status) =>
             if (!status) {
-              logger.warn(s"failed to execute create table :$code (执行建表失败):$code")
+              logger.warn(s"failed to execute create table :${CodeUtils
+                .maskCode(code, EngineType.SPARK.toString())} (执行建表失败):${CodeUtils
+                .maskCode(code, EngineType.SPARK.toString())}")
             }
         }
-      case _ => logger.warn(s"failed to execute create table:$code (执行建表失败:$code)")
+      case _ =>
+        logger.warn(
+          s"failed to execute create table:${CodeUtils.maskCode(code, EngineType.SPARK.toString())} (执行建表失败:${CodeUtils
+            .maskCode(code, EngineType.SPARK.toString())})"
+        )
     }
   }
 

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/metadata/MetaDataInfoTool.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/metadata/MetaDataInfoTool.scala
@@ -17,7 +17,8 @@
 
 package org.apache.linkis.engineplugin.spark.metadata
 
-import org.apache.linkis.common.utils.Logging
+import org.apache.linkis.common.utils.{CodeUtils, Logging}
+import org.apache.linkis.manager.label.entity.engine.EngineType
 
 import org.apache.spark.sql.{DataFrame, Dataset, SparkLogicalPlanHelper, SQLContext}
 
@@ -27,11 +28,15 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkLogicalPlanHelper, SQLCont
 class MetaDataInfoTool extends Logging {
 
   def getMetaDataInfo(sqlContext: SQLContext, sql: String, dataFrame: DataFrame): String = {
-    logger.info(s"begin to get sql metadata info: ${cutSql(sql)}")
+    logger.info(
+      s"begin to get sql metadata info: ${CodeUtils.maskCode(sql, EngineType.SPARK.toString())}"
+    )
     val startTime = System.currentTimeMillis
     val inputTables =
       SparkLogicalPlanHelper.extract(sqlContext, sql, dataFrame.queryExecution, startTime)
-    logger.info(s"end to get sql metadata info: ${cutSql(sql)}, metadata is ${inputTables}")
+    logger.info(
+      s"end to get sql metadata info: ${CodeUtils.maskCode(sql, EngineType.SPARK.toString())}, metadata is ${inputTables}"
+    )
     if (inputTables != null) inputTables.toString else ""
   }
 

--- a/linkis-engineconn-plugins/trino/src/main/scala/org/apache/linkis/engineplugin/trino/executor/TrinoEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/trino/src/main/scala/org/apache/linkis/engineplugin/trino/executor/TrinoEngineConnExecutor.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.engineplugin.trino.executor
 
 import org.apache.linkis.common.log.LogUtils
-import org.apache.linkis.common.utils.{OverloadUtils, Utils}
+import org.apache.linkis.common.utils.{CodeUtils, OverloadUtils, Utils}
 import org.apache.linkis.engineconn.acessible.executor.listener.event.TaskLogUpdateEvent
 import org.apache.linkis.engineconn.common.conf.{EngineConnConf, EngineConnConstant}
 import org.apache.linkis.engineconn.computation.executor.conf.ComputationExecutorConf
@@ -51,6 +51,7 @@ import org.apache.linkis.manager.common.entity.resource.{
 import org.apache.linkis.manager.engineplugin.common.util.NodeResourceUtils
 import org.apache.linkis.manager.label.entity.Label
 import org.apache.linkis.manager.label.entity.engine.{EngineTypeLabel, UserCreatorLabel}
+import org.apache.linkis.manager.label.entity.engine.EngineType
 import org.apache.linkis.protocol.engine.JobProgressInfo
 import org.apache.linkis.rpc.Sender
 import org.apache.linkis.scheduler.executer.{
@@ -161,7 +162,9 @@ class TrinoEngineConnExecutor(override val outputPrintLimit: Int, val id: Int)
     }
 
     TrinoCode.checkCode(realCode)
-    logger.info(s"trino client begins to run psql code:\n $realCode")
+    logger.info(
+      s"trino client begins to run psql code: ${CodeUtils.maskCode(realCode, EngineType.TRINO.toString())}"
+    )
     val jobId = JobUtils.getJobIdFromMap(engineExecutorContext.getProperties)
     // Add task id in the first line, and trino will customize it after receiving it.(在第一行加taskid，trino接收后做定制化处理)
     realCode = s"--linkis_task_id=$jobId" + "\n" + realCode

--- a/linkis-public-enhancements/linkis-bml-server/src/main/java/org/apache/linkis/bml/service/impl/ResourceServiceImpl.java
+++ b/linkis-public-enhancements/linkis-bml-server/src/main/java/org/apache/linkis/bml/service/impl/ResourceServiceImpl.java
@@ -95,6 +95,12 @@ public class ResourceServiceImpl implements ResourceService {
       // 插入一条记录到resource表
       long id = resourceDao.uploadResource(resource);
       logger.info("{} uploaded a resource and resourceId is {}", user, resource.getResourceId());
+      logger.info(
+          "Upload resource - resourceId: {}, version: {}, hdfsPath: {}, user: {}",
+          resource.getResourceId(),
+          Constant.FIRST_VERSION,
+          path,
+          user);
       // 插入一条记录到resource version表
       String clientIp = (String) properties.get("clientIp");
       ResourceVersion resourceVersion =

--- a/linkis-public-enhancements/linkis-bml-server/src/main/java/org/apache/linkis/bml/service/impl/VersionServiceImpl.java
+++ b/linkis-public-enhancements/linkis-bml-server/src/main/java/org/apache/linkis/bml/service/impl/VersionServiceImpl.java
@@ -115,6 +115,12 @@ public class VersionServiceImpl implements VersionService {
         ResourceVersion.createNewResourceVersion(
             resourceId, path, md5String, clientIp, size, newVersion, 1);
     versionDao.insertNewVersion(resourceVersion);
+    logger.info(
+        "Update resource version - resourceId: {}, version: {}, hdfsPath: {}, user: {}",
+        resourceId,
+        newVersion,
+        path,
+        user);
     // }
     return newVersion;
   }
@@ -150,6 +156,12 @@ public class VersionServiceImpl implements VersionService {
     inputStream.skip(startByte - 1); // NOSONAR
     logger.info(
         "{} downLoad source {} inputStream skipped {} bytes", user, resourceId, (startByte - 1));
+    logger.info(
+        "Download resource - resourceId: {}, version: {}, hdfsPath: {}, user: {}",
+        resourceId,
+        version,
+        path,
+        user);
     byte[] buffer = new byte[1024];
     long size = endByte - startByte + 1;
     int left = (int) size;

--- a/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/TemplateRestfulApi.java
+++ b/linkis-public-enhancements/linkis-configuration/src/main/java/org/apache/linkis/configuration/restful/api/TemplateRestfulApi.java
@@ -19,6 +19,7 @@ package org.apache.linkis.configuration.restful.api;
 
 import org.apache.linkis.common.conf.Configuration;
 import org.apache.linkis.common.utils.JsonUtils;
+import org.apache.linkis.common.utils.TokenSensitiveUtils;
 import org.apache.linkis.configuration.entity.ConfigKey;
 import org.apache.linkis.configuration.entity.ConfigKeyLimitVo;
 import org.apache.linkis.configuration.exception.ConfigurationException;
@@ -87,7 +88,9 @@ public class TemplateRestfulApi {
     // check special admin token
     if (StringUtils.isNotBlank(token)) {
       if (!Configuration.isAdminToken(token)) {
-        logger.warn("Token:{} has no permission to updateKeyMapping.", token);
+        logger.warn(
+            "Token:{} has no permission to updateKeyMapping.",
+            TokenSensitiveUtils.maskToken(token));
         return Message.error("Token:" + token + " has no permission to updateKeyMapping.");
       }
     } else if (!Configuration.isAdmin(username)) {
@@ -164,7 +167,9 @@ public class TemplateRestfulApi {
     // check special admin token
     if (StringUtils.isNotBlank(token)) {
       if (!Configuration.isAdminToken(token)) {
-        logger.warn("Token:{} has no permission to queryKeyInfoList.", token);
+        logger.warn(
+            "Token:{} has no permission to queryKeyInfoList.",
+            TokenSensitiveUtils.maskToken(token));
         return Message.error("Token has no permission to queryKeyInfoList.");
       }
     } else if (!Configuration.isAdmin(username)) {
@@ -216,7 +221,7 @@ public class TemplateRestfulApi {
     // check special admin token
     if (StringUtils.isNotBlank(token)) {
       if (!Configuration.isAdminToken(token)) {
-        logger.warn("Token:{} has no permission to apply.", token);
+        logger.warn("Token:{} has no permission to apply.", TokenSensitiveUtils.maskToken(token));
         return Message.error("Token:" + token + " has no permission to apply.");
       }
     } else if (!Configuration.isAdmin(username)) {

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hdfs/src/main/java/org/apache/linkis/metadata/query/service/HdfsConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hdfs/src/main/java/org/apache/linkis/metadata/query/service/HdfsConnection.java
@@ -43,26 +43,97 @@ public class HdfsConnection implements Closeable {
 
   public HdfsConnection(String scheme, String operator, String clusterLabel, boolean cache)
       throws IOException {
-    // TODO fix the problem of connecting multiple cluster in FSFactory.getFSByLabelAndUser
-    //        Fs fileSystem = FSFactory.getFSByLabelAndUser(scheme, operator, clusterLabel);
-    hadoopConf = HDFSUtils.getConfigurationByLabel(operator, clusterLabel);
-    fs = createFileSystem(operator, this.hadoopConf, cache);
+    long startTime = System.currentTimeMillis();
+    LOG.info(
+        "Creating HdfsConnection - scheme: {}, operator: {}, clusterLabel: {}, cache: {}",
+        scheme,
+        operator,
+        clusterLabel,
+        cache);
+
+    try {
+      // TODO fix the problem of connecting multiple cluster in FSFactory.getFSByLabelAndUser
+      //        Fs fileSystem = FSFactory.getFSByLabelAndUser(scheme, operator, clusterLabel);
+      hadoopConf = HDFSUtils.getConfigurationByLabel(operator, clusterLabel);
+      LOG.info(
+          "Hadoop configuration loaded for HdfsConnection - operator: {}, clusterLabel: {}",
+          operator,
+          clusterLabel);
+      fs = createFileSystem(operator, this.hadoopConf, cache);
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "HdfsConnection created successfully - operator: {}, clusterLabel: {}, duration: {}",
+          operator,
+          clusterLabel,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to create HdfsConnection - operator: {}, clusterLabel: {}, duration: {}",
+          operator,
+          clusterLabel,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
+    }
   }
 
   public HdfsConnection(
       String scheme, String operator, Map<String, String> configuration, boolean cache) {
-    if (Objects.nonNull(configuration)) {
-      hadoopConf = new Configuration();
-      configuration.forEach(hadoopConf::set);
-    } else {
-      hadoopConf = HDFSUtils.getConfiguration(operator);
+    long startTime = System.currentTimeMillis();
+    LOG.info(
+        "Creating HdfsConnection with custom config - scheme: {}, operator: {}, cache: {}, configSize: {}",
+        scheme,
+        operator,
+        cache,
+        configuration != null ? configuration.size() : 0);
+
+    try {
+      if (Objects.nonNull(configuration)) {
+        hadoopConf = new Configuration();
+        configuration.forEach(hadoopConf::set);
+      } else {
+        hadoopConf = HDFSUtils.getConfiguration(operator);
+      }
+      fs = createFileSystem(operator, this.hadoopConf, cache);
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "HdfsConnection with custom config created successfully - operator: {}, duration: {}",
+          operator,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to create HdfsConnection with custom config - operator: {}, duration: {}",
+          operator,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
     }
-    fs = createFileSystem(operator, this.hadoopConf, cache);
   }
 
   @Override
   public void close() throws IOException {
-    this.fs.close();
+    long startTime = System.currentTimeMillis();
+    LOG.info("Closing HdfsConnection");
+
+    try {
+      this.fs.close();
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "HdfsConnection closed successfully - duration: {}",
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to close HdfsConnection - duration: {}",
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
+    }
   }
 
   /**
@@ -100,9 +171,29 @@ public class HdfsConnection implements Closeable {
    * @return file system
    */
   private FileSystem createFileSystem(String operator, Configuration hadoopConf, boolean cache) {
-    if (!cache) {
-      hadoopConf.set("fs.hdfs.impl.disable.cache", "true");
+    long startTime = System.currentTimeMillis();
+    LOG.info("Creating FileSystem for HdfsConnection - operator: {}, cache: {}", operator, cache);
+
+    try {
+      if (!cache) {
+        hadoopConf.set("fs.hdfs.impl.disable.cache", "true");
+      }
+      FileSystem fs = HDFSUtils.createFileSystem(operator, hadoopConf);
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "FileSystem created for HdfsConnection - operator: {}, duration: {}",
+          operator,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+      return fs;
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to create FileSystem for HdfsConnection - operator: {}, duration: {}",
+          operator,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
     }
-    return HDFSUtils.createFileSystem(operator, hadoopConf);
   }
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hive/src/main/java/org/apache/linkis/metadata/query/service/HiveConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/hive/src/main/java/org/apache/linkis/metadata/query/service/HiveConnection.java
@@ -33,9 +33,14 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.apache.hadoop.fs.FileSystem.FS_DEFAULT_NAME_KEY;
 
 public class HiveConnection implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveConnection.class);
 
   private Hive hiveClient;
 
@@ -60,37 +65,79 @@ public class HiveConnection implements Closeable {
   public HiveConnection(
       String uris, String principle, String keytabFilePath, Map<String, String> hadoopConf)
       throws Exception {
-    final HiveConf conf = new HiveConf();
-    conf.setVar(HiveConf.ConfVars.METASTOREURIS, uris);
-    conf.setVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL, "true");
-    conf.setVar(
-        HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL, KERBEROS_DEFAULT_PRINCIPLE.getValue());
-    // Disable the cache in FileSystem
-    conf.setBoolean(
-        String.format(
-            "fs.%s.impl.disable.cache", URI.create(conf.get(FS_DEFAULT_NAME_KEY, "")).getScheme()),
-        true);
-    conf.set("hadoop.security.authentication", "kerberos");
-    hadoopConf.forEach(conf::set);
-    principle = principle.substring(0, principle.indexOf("@"));
-    UserGroupInformation ugi =
-        UserGroupInformationWrapper.loginUserFromKeytab(conf, principle, keytabFilePath);
-    hiveClient = getHive(ugi, conf);
+    long startTime = System.currentTimeMillis();
+    LOG.info("Creating HiveConnection with Kerberos - uris: {}, principle: {}", uris, principle);
+
+    try {
+      final HiveConf conf = new HiveConf();
+      conf.setVar(HiveConf.ConfVars.METASTOREURIS, uris);
+      conf.setVar(HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL, "true");
+      conf.setVar(
+          HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL, KERBEROS_DEFAULT_PRINCIPLE.getValue());
+      // Disable the cache in FileSystem
+      conf.setBoolean(
+          String.format(
+              "fs.%s.impl.disable.cache",
+              URI.create(conf.get(FS_DEFAULT_NAME_KEY, "")).getScheme()),
+          true);
+      conf.set("hadoop.security.authentication", "kerberos");
+      hadoopConf.forEach(conf::set);
+      principle = principle.substring(0, principle.indexOf("@"));
+
+      LOG.info("Performing Kerberos login - principle: {}, keytab: {}", principle, keytabFilePath);
+      UserGroupInformation ugi =
+          UserGroupInformationWrapper.loginUserFromKeytab(conf, principle, keytabFilePath);
+      hiveClient = getHive(ugi, conf);
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "HiveConnection with Kerberos created successfully - uris: {}, duration: {}",
+          uris,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to create HiveConnection with Kerberos - uris: {}, duration: {}",
+          uris,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
+    }
   }
 
   public HiveConnection(String uris, Map<String, String> hadoopConf) throws Exception {
-    final HiveConf conf = new HiveConf();
-    conf.setVar(HiveConf.ConfVars.METASTOREURIS, uris);
-    hadoopConf.forEach(conf::set);
-    // Disable the cache in FileSystem
-    conf.setBoolean(
-        String.format(
-            "fs.%s.impl.disable.cache", URI.create(conf.get(FS_DEFAULT_NAME_KEY, "")).getScheme()),
-        true);
-    // TODO choose an authentication strategy for hive, and then use createProxyUser
-    UserGroupInformation ugi =
-        UserGroupInformation.createRemoteUser(DEFAULT_SERVICE_USER.getValue());
-    hiveClient = getHive(ugi, conf);
+    long startTime = System.currentTimeMillis();
+    LOG.info("Creating HiveConnection with simple auth - uris: {}", uris);
+
+    try {
+      final HiveConf conf = new HiveConf();
+      conf.setVar(HiveConf.ConfVars.METASTOREURIS, uris);
+      hadoopConf.forEach(conf::set);
+      // Disable the cache in FileSystem
+      conf.setBoolean(
+          String.format(
+              "fs.%s.impl.disable.cache",
+              URI.create(conf.get(FS_DEFAULT_NAME_KEY, "")).getScheme()),
+          true);
+      // TODO choose an authentication strategy for hive, and then use createProxyUser
+      UserGroupInformation ugi =
+          UserGroupInformation.createRemoteUser(DEFAULT_SERVICE_USER.getValue());
+      hiveClient = getHive(ugi, conf);
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "HiveConnection with simple auth created successfully - uris: {}, duration: {}",
+          uris,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to create HiveConnection with simple auth - uris: {}, duration: {}",
+          uris,
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
+    }
   }
   /**
    * Get Hive client(Hive object)
@@ -116,8 +163,25 @@ public class HiveConnection implements Closeable {
 
   @Override
   public void close() throws IOException {
-    // Close meta store client
-    metaStoreClient.close();
+    long startTime = System.currentTimeMillis();
+    LOG.info("Closing HiveConnection");
+
+    try {
+      // Close meta store client
+      metaStoreClient.close();
+
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.info(
+          "HiveConnection closed successfully - duration: {}",
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration));
+    } catch (Exception e) {
+      long duration = System.currentTimeMillis() - startTime;
+      LOG.error(
+          "Failed to close HiveConnection - duration: {}",
+          org.apache.linkis.common.utils.ByteTimeUtils.msDurationToString(duration),
+          e);
+      throw e;
+    }
   }
 
   /** Wrapper class of UserGroupInformation */

--- a/linkis-public-enhancements/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
+++ b/linkis-public-enhancements/linkis-jobhistory/src/main/scala/org/apache/linkis/jobhistory/service/impl/JobHistoryQueryServiceImpl.scala
@@ -30,6 +30,7 @@ import org.apache.linkis.governance.common.entity.job.{
 }
 import org.apache.linkis.governance.common.protocol.conf.EntranceInstanceConfRequest
 import org.apache.linkis.governance.common.protocol.job._
+import org.apache.linkis.governance.common.utils.LoggerUtils
 import org.apache.linkis.jobhistory.conf.JobhistoryConfiguration
 import org.apache.linkis.jobhistory.conversions.TaskConversions._
 import org.apache.linkis.jobhistory.dao.JobHistoryMapper
@@ -154,79 +155,86 @@ class JobHistoryQueryServiceImpl extends JobHistoryQueryService with Logging {
   override def change(jobReqUpdate: JobReqUpdate): JobRespProtocol = {
     val jobReq = jobReqUpdate.jobReq
     jobReq.setExecutionCode(null)
-    logger.info(
-      "Update data to the database(往数据库中更新数据)：task " + jobReq.getId + "status:" + jobReq.getStatus
-    )
+    if (jobReq.getId != null) {
+      LoggerUtils.setJobIdMDC(jobReq.getId.toString)
+    }
     val jobResp = new JobRespProtocol
-    Utils.tryCatch {
-      if (jobReq.getErrorDesc != null) {
-        if (jobReq.getErrorDesc.length > GovernanceCommonConf.ERROR_CODE_DESC_LEN) {
-          logger.info(s"errorDesc is too long,we will cut some message")
-          jobReq.setErrorDesc(
-            jobReq.getErrorDesc.substring(0, GovernanceCommonConf.ERROR_CODE_DESC_LEN - 3) + "..."
-          )
-          logger.info(s"${jobReq.getErrorDesc}")
-        }
-      }
-      if (jobReq.getStatus != null) {
-        val oldStatus: String = jobHistoryMapper.selectJobHistoryStatusForUpdate(jobReq.getId)
-        val startUpMap: util.Map[String, AnyRef] =
-          TaskUtils.getStartupMap(jobReqUpdate.jobReq.getParams)
-        val taskRetrySwitch: AnyRef = startUpMap.getOrDefault("linkis.task.retry.switch", "false")
-        if (
-            oldStatus != null && !shouldUpdate(
-              oldStatus,
-              jobReq.getStatus,
-              taskRetrySwitch.toString
+    try {
+      logger.info(
+        "Update data to the database(往数据库中更新数据)：task " + jobReq.getId + "status:" + jobReq.getStatus
+      )
+      Utils.tryCatch {
+        if (jobReq.getErrorDesc != null) {
+          if (jobReq.getErrorDesc.length > GovernanceCommonConf.ERROR_CODE_DESC_LEN) {
+            logger.info(s"errorDesc is too long,we will cut some message")
+            jobReq.setErrorDesc(
+              jobReq.getErrorDesc.substring(0, GovernanceCommonConf.ERROR_CODE_DESC_LEN - 3) + "..."
             )
+            logger.info(s"${jobReq.getErrorDesc}")
+          }
+        }
+        if (jobReq.getStatus != null) {
+          val oldStatus: String = jobHistoryMapper.selectJobHistoryStatusForUpdate(jobReq.getId)
+          val startUpMap: util.Map[String, AnyRef] =
+            TaskUtils.getStartupMap(jobReqUpdate.jobReq.getParams)
+          val taskRetrySwitch: AnyRef = startUpMap.getOrDefault("linkis.task.retry.switch", "false")
+          if (
+              oldStatus != null && !shouldUpdate(
+                oldStatus,
+                jobReq.getStatus,
+                taskRetrySwitch.toString
+              )
+          ) {
+            throw new QueryException(
+              120001,
+              s"jobId:${jobReq.getId}，oldStatus(在数据库中的task状态为)：${oldStatus}," +
+                s" newStatus(更新的task状态为)：${jobReq.getStatus}，update failed(更新失败)！"
+            )
+          }
+        }
+
+        // metrics 增量更新逻辑
+        if (
+            Configuration.METRICS_INCREMENTAL_UPDATE_ENABLE.getValue &&
+            jobReq.getMetrics != null && !jobReq.getMetrics.isEmpty
         ) {
+          mergeMetrics(jobReq)
+        }
+
+        val jobUpdate = jobRequest2JobHistory(jobReq)
+        if (jobUpdate.getUpdatedTime == null) {
           throw new QueryException(
             120001,
-            s"jobId:${jobReq.getId}，oldStatus(在数据库中的task状态为)：${oldStatus}," +
-              s" newStatus(更新的task状态为)：${jobReq.getStatus}，update failed(更新失败)！"
+            s"jobId:${jobReq.getId}，update job failed, updatetime needed(更新job相关信息失败，请指定该请求的更新时间)!"
           )
         }
-      }
-
-      // metrics 增量更新逻辑
-      if (
-          Configuration.METRICS_INCREMENTAL_UPDATE_ENABLE.getValue &&
-          jobReq.getMetrics != null && !jobReq.getMetrics.isEmpty
-      ) {
-        mergeMetrics(jobReq)
-      }
-
-      val jobUpdate = jobRequest2JobHistory(jobReq)
-      if (jobUpdate.getUpdatedTime == null) {
-        throw new QueryException(
-          120001,
-          s"jobId:${jobReq.getId}，update job failed, updatetime needed(更新job相关信息失败，请指定该请求的更新时间)!"
+        logger.info(
+          s"Update data to the database(往数据库中更新数据)：task ${jobReq.getId} ,status ${jobReq.getStatus}," +
+            s" updateTime: ${jobUpdate.getUpdateTimeMills}, progress : ${jobUpdate.getProgress}"
         )
+        jobHistoryMapper.updateJobHistory(jobUpdate)
+        val map = new util.HashMap[String, Object]
+        map.put(JobRequestConstants.JOB_ID, jobReq.getId.asInstanceOf[Object])
+        jobResp.setStatus(0)
+        jobResp.setData(map)
+      } {
+        case exception: QueryException =>
+          logger.error(
+            s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
+            exception
+          )
+          jobResp.setStatus(1)
+          jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
+        case exception: Exception =>
+          logger.error(
+            s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
+            exception
+          )
+          jobResp.setStatus(2)
+          jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
       }
-      logger.info(
-        s"Update data to the database(往数据库中更新数据)：task ${jobReq.getId} ,status ${jobReq.getStatus}," +
-          s" updateTime: ${jobUpdate.getUpdateTimeMills}, progress : ${jobUpdate.getProgress}"
-      )
-      jobHistoryMapper.updateJobHistory(jobUpdate)
-      val map = new util.HashMap[String, Object]
-      map.put(JobRequestConstants.JOB_ID, jobReq.getId.asInstanceOf[Object])
-      jobResp.setStatus(0)
-      jobResp.setData(map)
-    } {
-      case exception: QueryException =>
-        logger.error(
-          s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
-          exception
-        )
-        jobResp.setStatus(1)
-        jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
-      case exception: Exception =>
-        logger.error(
-          s"Failed to update JobReqUpdate ${jobReq.getId},status ${jobReq.getStatus}",
-          exception
-        )
-        jobResp.setStatus(2)
-        jobResp.setMsg(ExceptionUtils.getRootCauseMessage(exception))
+    } finally {
+      LoggerUtils.removeJobIdMDC()
     }
     jobResp
   }

--- a/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/token/TokenAuthentication.scala
+++ b/linkis-spring-cloud-services/linkis-service-gateway/linkis-gateway-core/src/main/scala/org/apache/linkis/gateway/security/token/TokenAuthentication.scala
@@ -17,7 +17,7 @@
 
 package org.apache.linkis.gateway.security.token
 
-import org.apache.linkis.common.utils.{Logging, MD5Utils, Utils}
+import org.apache.linkis.common.utils.{Logging, MD5Utils, TokenSensitiveUtils, Utils}
 import org.apache.linkis.gateway.authentication.service.TokenService
 import org.apache.linkis.gateway.config.GatewayConfiguration
 import org.apache.linkis.gateway.config.GatewayConfiguration._
@@ -61,7 +61,12 @@ object TokenAuthentication extends Logging {
     var host = gatewayContext.getRequest.getRequestRealIpAddr()
     logger.info(
       String
-        .format("Use Linkis Auth : %s,User : %s,Ip : %s", encryptToken(token), tokenUser, host)
+        .format(
+          "Use Linkis Auth : %s,User : %s,Ip : %s",
+          TokenSensitiveUtils.maskToken(token),
+          tokenUser,
+          host
+        )
     )
     if (StringUtils.isBlank(token) || StringUtils.isBlank(tokenUser)) {
       val cookieTokenOpt = Option(gatewayContext.getRequest.getCookies.get(TOKEN_KEY)).map(_.head)
@@ -107,11 +112,13 @@ object TokenAuthentication extends Logging {
     })
     if (ok) {
       logger.info(
-        s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: $token, tokenUser: $tokenUser, host: $host."
+        s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: ${TokenSensitiveUtils
+          .maskToken(token)}, tokenUser: $tokenUser, host: $host."
       )
       if (login) {
         logger.info(
-          s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: $token, tokenUser: $tokenUser."
+          s"Token authentication succeed, uri: ${gatewayContext.getRequest.getRequestURI}, token: ${TokenSensitiveUtils
+            .maskToken(token)}, tokenUser: $tokenUser."
         )
         GatewaySSOUtils.setLoginUser(gatewayContext, tokenUser)
         val msg =
@@ -130,7 +137,8 @@ object TokenAuthentication extends Logging {
       true
     } else {
       logger.info(
-        s"Token authentication fail, uri: ${gatewayContext.getRequest.getRequestURI}, token: $token, tokenUser: $tokenUser, host: $host."
+        s"Token authentication fail, uri: ${gatewayContext.getRequest.getRequestURI}, token: ${TokenSensitiveUtils
+          .maskToken(token)}, tokenUser: $tokenUser, host: $host."
       )
       SecurityFilter.filterResponse(gatewayContext, authMsg)
       false

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,6 @@
     <druid.version>1.2.4</druid.version>
     <javassist.version>3.27.0-GA</javassist.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-text.version>1.10.0</commons-text.version>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
Currently, Linkis engine logs expose sensitive information including user authentication tokens and user execution code in plain text. This poses significant security risks as these logs can be accessed by multiple users and stored indefinitely. Additionally, kill engine operations lack proper instance logging, making debugging difficult.

**Purpose of Change:**
To address this security issue, this PR adds comprehensive log filtering functionality by introducing CodeUtils and TokenSensitiveUtils classes to mask tokens and user code across all engine plugins. It also enhances logging in engine kill operations to include instance information for better traceability.

**Value/Impact:**
After the change, sensitive information is properly masked in all engine logs, significantly improving system security and compliance. Enhanced instance logging during kill operations improves debugging and operational monitoring capabilities.

### Related issues/PRs

Related issues: close #1047
Related pr:none

### Brief change log

- Add CodeUtils and TokenSensitiveUtils classes for sensitive data filtering
- Apply token masking across all engine plugins (Spark, Hive, Flink, Python, Shell, JDBC, Trino, Nebula, Seatunnel)
- Apply user code filtering in engine execution logs
- Enhance engine kill operation logging with instance information
- Update HDFSFileSystem to use filtered logging
- Update datasource connection services to use filtered logging
- Add unit tests for TokenSensitiveUtils
- Update log4j2 configuration in Spark engine

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.