### PR TITLE
[fix][COM][kerberos] fix bml service oom issue when keytab is enabled in cluster mode

### DIFF
--- a/linkis-commons/linkis-hadoop-common/src/main/scala/org/apache/linkis/hadoop/common/conf/HadoopConf.scala
+++ b/linkis-commons/linkis-hadoop-common/src/main/scala/org/apache/linkis/hadoop/common/conf/HadoopConf.scala
@@ -75,4 +75,10 @@ object HadoopConf {
   val HDFS_ENABLE_CACHE_MAX_TIME =
     CommonVars("wds.linkis.hadoop.hdfs.cache.max.time", new TimeType("12h")).getValue.toLong
 
+  /**
+   * Temporary directory for keytab files when LINKIS_KEYTAB_SWITCH is enabled 默认使用系统临时目录下的 keytab
+   * 子目录
+   */
+  val KEYTAB_TEMP_DIR = CommonVars("linkis.keytab.temp.dir", "/tmp/keytab")
+
 }

--- a/linkis-commons/linkis-hadoop-common/src/main/scala/org/apache/linkis/hadoop/common/utils/HDFSUtils.scala
+++ b/linkis-commons/linkis-hadoop-common/src/main/scala/org/apache/linkis/hadoop/common/utils/HDFSUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.linkis.hadoop.common.utils
 
 import org.apache.linkis.common.conf.Configuration.LINKIS_KEYTAB_SWITCH
-import org.apache.linkis.common.utils.{AESUtils, Logging, Utils}
+import org.apache.linkis.common.utils.{AESUtils, ByteTimeUtils, Logging, Utils}
 import org.apache.linkis.hadoop.common.conf.HadoopConf
 import org.apache.linkis.hadoop.common.conf.HadoopConf._
 import org.apache.linkis.hadoop.common.entity.HDFSFileSystemContainer
@@ -39,10 +39,55 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.JavaConverters._
 
+import com.google.common.cache.{
+  CacheBuilder,
+  LoadingCache,
+  RemovalCause,
+  RemovalListener,
+  RemovalNotification
+}
+
 object HDFSUtils extends Logging {
 
   private val fileSystemCache: java.util.Map[String, HDFSFileSystemContainer] =
     new ConcurrentHashMap[String, HDFSFileSystemContainer]()
+
+  // 缓存keytab文件路径，避免重复创建临时文件导致KeyTab对象内存泄漏
+  private val keytabTempFileCache: LoadingCache[String, String] = {
+    val removalListener = new RemovalListener[String, String] {
+      override def onRemoval(notification: RemovalNotification[String, String]): Unit = {
+        val key = notification.getKey
+        val path = notification.getValue
+        val cause = notification.getCause
+
+        logger.info(s"Keytab cache entry removed: $key, cause: $cause")
+
+        // 当缓存项被移除时，清理对应的临时文件
+        if (path != null) {
+          val file = new File(path)
+          if (file.exists()) {
+            if (file.delete()) {
+              logger.info(s"Removed keytab temp file: $path")
+            } else {
+              logger.warn(s"Failed to remove keytab temp file: $path")
+            }
+          }
+        }
+      }
+    }
+
+    CacheBuilder
+      .newBuilder()
+      .maximumSize(1000) // 最大缓存项数量
+      .expireAfterAccess(24, TimeUnit.HOURS) // 24小时未访问过期
+      .removalListener(removalListener)
+      .build(new com.google.common.cache.CacheLoader[String, String] {
+        override def load(key: String): String = {
+          // 这里不应该被调用，因为我们总是在put之前检查缓存
+          throw new UnsupportedOperationException("Cache loader not supported")
+        }
+      })
+  }
 
   private val LOCKER_SUFFIX = "_HDFS"
   private val DEFAULT_CACHE_LABEL = "default"
@@ -94,6 +139,20 @@ object HDFSUtils extends Logging {
     )
   }
 
+  /**
+   * 创建 keytab 缓存的 key，考虑 label 参数
+   */
+  private def createKeytabCacheKey(userName: String, label: String): String = {
+    if (label == null) userName else s"$userName#$label"
+  }
+
+  /**
+   * 获取 keytab 临时文件目录
+   */
+  private def getKeytabTempDir(): java.nio.file.Path = {
+    Paths.get(HadoopConf.KEYTAB_TEMP_DIR.getValue)
+  }
+
   def getConfiguration(user: String): Configuration = getConfiguration(user, hadoopConfDir)
 
   def getConfigurationByLabel(user: String, label: String): Configuration = {
@@ -114,20 +173,38 @@ object HDFSUtils extends Logging {
   }
 
   def getConfiguration(user: String, hadoopConfDir: String): Configuration = {
-    val confPath = new File(hadoopConfDir)
-    if (!confPath.exists() || confPath.isFile) {
-      throw new RuntimeException(
-        s"Create hadoop configuration failed, path $hadoopConfDir not exists."
+    val startTime = System.currentTimeMillis()
+    logger.info(s"Loading Hadoop configuration - user: $user, configDir: $hadoopConfDir")
+    try {
+      val confPath = new File(hadoopConfDir)
+      if (!confPath.exists() || confPath.isFile) {
+        throw new RuntimeException(
+          s"Create hadoop configuration failed, path $hadoopConfDir not exists."
+        )
+      }
+      val conf = new Configuration()
+      conf.addResource(
+        new Path(Paths.get(hadoopConfDir, "core-site.xml").toAbsolutePath.toFile.getAbsolutePath)
       )
+      conf.addResource(
+        new Path(Paths.get(hadoopConfDir, "hdfs-site.xml").toAbsolutePath.toFile.getAbsolutePath)
+      )
+      val duration = System.currentTimeMillis() - startTime
+      logger.info(
+        s"Hadoop configuration loaded successfully - user: $user, configDir: $hadoopConfDir, duration: ${ByteTimeUtils
+          .msDurationToString(duration)}"
+      )
+      conf
+    } catch {
+      case e: Exception =>
+        val duration = System.currentTimeMillis() - startTime
+        logger.error(
+          s"Failed to load Hadoop configuration - user: $user, configDir: $hadoopConfDir, duration: ${ByteTimeUtils
+            .msDurationToString(duration)}",
+          e
+        )
+        throw e
     }
-    val conf = new Configuration()
-    conf.addResource(
-      new Path(Paths.get(hadoopConfDir, "core-site.xml").toAbsolutePath.toFile.getAbsolutePath)
-    )
-    conf.addResource(
-      new Path(Paths.get(hadoopConfDir, "hdfs-site.xml").toAbsolutePath.toFile.getAbsolutePath)
-    )
-    conf
   }
 
   def getHDFSRootUserFileSystem: FileSystem = getHDFSRootUserFileSystem(
@@ -215,11 +292,32 @@ object HDFSUtils extends Logging {
       conf: org.apache.hadoop.conf.Configuration
   ): FileSystem = {
     val createCount = count.getAndIncrement()
-    logger.info(s"user ${userName} to create Fs, create time ${createCount}")
-    getUserGroupInformation(userName, label)
-      .doAs(new PrivilegedExceptionAction[FileSystem] {
-        def run: FileSystem = FileSystem.newInstance(conf)
-      })
+    val startTime = System.currentTimeMillis()
+    val labelInfo = if (label == null) "default" else label
+    logger.info(
+      s"Creating Hadoop FileSystem - user: $userName, label: $labelInfo, createCount: $createCount"
+    )
+    try {
+      val fs = getUserGroupInformation(userName, label)
+        .doAs(new PrivilegedExceptionAction[FileSystem] {
+          def run: FileSystem = FileSystem.newInstance(conf)
+        })
+      val duration = System.currentTimeMillis() - startTime
+      logger.info(
+        s"Hadoop FileSystem created successfully - user: $userName, label: $labelInfo, duration: ${ByteTimeUtils
+          .msDurationToString(duration)}, createCount: $createCount"
+      )
+      fs
+    } catch {
+      case e: Exception =>
+        val duration = System.currentTimeMillis() - startTime
+        logger.error(
+          s"Failed to create Hadoop FileSystem - user: $userName, label: $labelInfo, duration: ${ByteTimeUtils
+            .msDurationToString(duration)}, createCount: $createCount",
+          e
+        )
+        throw e
+    }
   }
 
   def closeHDFSFIleSystem(fileSystem: FileSystem, userName: String): Unit =
@@ -240,29 +338,48 @@ object HDFSUtils extends Logging {
       isForce: Boolean
   ): Unit =
     if (null != fileSystem && StringUtils.isNotBlank(userName)) {
-      val locker = userName + LOCKER_SUFFIX
-      if (HadoopConf.HDFS_ENABLE_CACHE) locker.intern().synchronized {
-        val cacheLabel = if (label == null) DEFAULT_CACHE_LABEL else label
-        val cacheKey = userName + JOINT + cacheLabel
-        val hdfsFileSystemContainer = fileSystemCache.get(cacheKey)
-        if (
-            null != hdfsFileSystemContainer && fileSystem == hdfsFileSystemContainer.getFileSystem
-        ) {
-          if (isForce) {
-            fileSystemCache.remove(hdfsFileSystemContainer.getUser)
-            IOUtils.closeQuietly(hdfsFileSystemContainer.getFileSystem)
-            logger.info(
-              s"user${hdfsFileSystemContainer.getUser} to Force remove hdfsFileSystemContainer"
-            )
+      val startTime = System.currentTimeMillis()
+      val labelInfo = if (label == null) "default" else label
+      logger.info(
+        s"Closing Hadoop FileSystem - user: $userName, label: $labelInfo, force: $isForce"
+      )
+      try {
+        val locker = userName + LOCKER_SUFFIX
+        if (HadoopConf.HDFS_ENABLE_CACHE) locker.intern().synchronized {
+          val cacheLabel = if (label == null) DEFAULT_CACHE_LABEL else label
+          val cacheKey = userName + JOINT + cacheLabel
+          val hdfsFileSystemContainer = fileSystemCache.get(cacheKey)
+          if (
+              null != hdfsFileSystemContainer && fileSystem == hdfsFileSystemContainer.getFileSystem
+          ) {
+            if (isForce) {
+              fileSystemCache.remove(hdfsFileSystemContainer.getUser)
+              IOUtils.closeQuietly(hdfsFileSystemContainer.getFileSystem)
+              logger.info(s"Force closed Hadoop FileSystem - user: $userName, label: $labelInfo")
+            } else {
+              hdfsFileSystemContainer.minusAccessCount()
+            }
           } else {
-            hdfsFileSystemContainer.minusAccessCount()
+            IOUtils.closeQuietly(fileSystem)
           }
-        } else {
+        }
+        else {
           IOUtils.closeQuietly(fileSystem)
         }
-      }
-      else {
-        IOUtils.closeQuietly(fileSystem)
+        val duration = System.currentTimeMillis() - startTime
+        logger.info(
+          s"Hadoop FileSystem closed successfully - user: $userName, label: $labelInfo, duration: ${ByteTimeUtils
+            .msDurationToString(duration)}"
+        )
+      } catch {
+        case e: Exception =>
+          val duration = System.currentTimeMillis() - startTime
+          logger.error(
+            s"Failed to close Hadoop FileSystem - user: $userName, label: $labelInfo, duration: ${ByteTimeUtils
+              .msDurationToString(duration)}",
+            e
+          )
+          throw e
       }
     }
 
@@ -271,24 +388,51 @@ object HDFSUtils extends Logging {
   }
 
   def getUserGroupInformation(userName: String, label: String): UserGroupInformation = {
-    if (isKerberosEnabled(label)) {
-      if (!isKeytabProxyUserEnabled(label)) {
-        val path = getLinkisUserKeytabFile(userName, label)
-        val user = getKerberosUser(userName, label)
-        UserGroupInformation.setConfiguration(getConfigurationByLabel(userName, label))
-        UserGroupInformation.loginUserFromKeytabAndReturnUGI(user, path)
-      } else {
-        val superUser = getKeytabSuperUser(label)
-        val path = getLinkisUserKeytabFile(superUser, label)
-        val user = getKerberosUser(superUser, label)
-        UserGroupInformation.setConfiguration(getConfigurationByLabel(superUser, label))
-        UserGroupInformation.createProxyUser(
-          userName,
+    val startTime = System.currentTimeMillis()
+    val labelInfo = if (label == null) "default" else label
+    val authMethod = if (isKerberosEnabled(label)) "kerberos" else "simple"
+    logger.info(
+      s"Getting UserGroupInformation - user: $userName, label: $labelInfo, authMethod: $authMethod"
+    )
+    try {
+      val ugi = if (isKerberosEnabled(label)) {
+        if (!isKeytabProxyUserEnabled(label)) {
+          val path = getLinkisUserKeytabFile(userName, label)
+          val user = getKerberosUser(userName, label)
+          logger.info(s"Performing Kerberos login with keytab - user: $userName, label: $labelInfo")
+          UserGroupInformation.setConfiguration(getConfigurationByLabel(userName, label))
           UserGroupInformation.loginUserFromKeytabAndReturnUGI(user, path)
-        )
+        } else {
+          val superUser = getKeytabSuperUser(label)
+          val path = getLinkisUserKeytabFile(superUser, label)
+          val user = getKerberosUser(superUser, label)
+          logger.info(
+            s"Performing Kerberos login with proxy user - user: $userName, superUser: $superUser, label: $labelInfo"
+          )
+          UserGroupInformation.setConfiguration(getConfigurationByLabel(superUser, label))
+          UserGroupInformation.createProxyUser(
+            userName,
+            UserGroupInformation.loginUserFromKeytabAndReturnUGI(user, path)
+          )
+        }
+      } else {
+        UserGroupInformation.createRemoteUser(userName)
       }
-    } else {
-      UserGroupInformation.createRemoteUser(userName)
+      val duration = System.currentTimeMillis() - startTime
+      logger.info(
+        s"UserGroupInformation obtained successfully - user: $userName, label: $labelInfo, authMethod: $authMethod, duration: ${ByteTimeUtils
+          .msDurationToString(duration)}"
+      )
+      ugi
+    } catch {
+      case e: Exception =>
+        val duration = System.currentTimeMillis() - startTime
+        logger.error(
+          s"Failed to get UserGroupInformation - user: $userName, label: $labelInfo, authMethod: $authMethod, duration: ${ByteTimeUtils
+            .msDurationToString(duration)}",
+          e
+        )
+        throw e
     }
   }
 
@@ -382,18 +526,72 @@ object HDFSUtils extends Logging {
 
   private def getLinkisUserKeytabFile(userName: String, label: String): String = {
     val path = if (LINKIS_KEYTAB_SWITCH) {
-      // 读取文件
-      val byte = Files.readAllBytes(Paths.get(getLinkisKeytabPath(label), userName + KEYTAB_SUFFIX))
-      // 加密内容// 加密内容
-      val encryptedContent = AESUtils.decrypt(byte, AESUtils.PASSWORD)
-      val tempFile = Files.createTempFile(userName, KEYTAB_SUFFIX)
-      Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rw-------"))
-      Files.write(tempFile, encryptedContent)
-      tempFile.toString
+      try {
+        val cacheKey = createKeytabCacheKey(userName, label)
+        val keytabTempDir = getKeytabTempDir()
+        synchronized {
+          // 确保keytab临时目录存在
+          if (!Files.exists(keytabTempDir)) {
+            Files.createDirectories(keytabTempDir)
+            Files.setPosixFilePermissions(
+              keytabTempDir,
+              PosixFilePermissions.fromString("rwxr-xr-x")
+            )
+          }
+
+          val cachedPath = keytabTempFileCache.getIfPresent(cacheKey)
+          if (cachedPath != null) {
+            val tempFile = new File(cachedPath)
+            if (tempFile.exists()) {
+              logger.info(s"Found cached keytab file: $cachedPath")
+              cachedPath
+            } else {
+              logger.info(s"Cached keytab file not exists, removing from cache: $cachedPath")
+              // 文件不存在，从缓存中移除
+              keytabTempFileCache.invalidate(cacheKey)
+              // 创建新的临时文件
+              createNewKeytabFile(userName, label, keytabTempDir, cacheKey)
+            }
+          } else {
+            logger.info(s"Creating new keytab file for cacheKey: $cacheKey")
+            // 创建新的临时文件
+            createNewKeytabFile(userName, label, keytabTempDir, cacheKey)
+          }
+        }
+      } catch {
+        case _: Throwable => new File(getKeytabPath(label), userName + KEYTAB_SUFFIX).getPath
+      }
     } else {
       new File(getKeytabPath(label), userName + KEYTAB_SUFFIX).getPath
     }
     path
+  }
+
+  private def createNewKeytabFile(
+      userName: String,
+      label: String,
+      keytabTempDir: java.nio.file.Path,
+      cacheKey: String
+  ): String = {
+    try {
+      // 读取文件
+      val sourcePath = Paths.get(getLinkisKeytabPath(label), userName + KEYTAB_SUFFIX)
+      val byte = Files.readAllBytes(sourcePath)
+      // 解密内容
+      val encryptedContent = AESUtils.decrypt(byte, AESUtils.PASSWORD)
+      val tempFile = Files.createTempFile(keytabTempDir, null, KEYTAB_SUFFIX)
+      Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rw-------"))
+      Files.write(tempFile, encryptedContent)
+      val keyTablePath = tempFile.toString
+      // 将固定文件路径加入缓存
+      keytabTempFileCache.put(cacheKey, keyTablePath)
+      logger.info(s"Created and cached fixed keytab file: $keyTablePath, cacheKey: $cacheKey")
+      keyTablePath
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to create keytab file for user: $userName", e)
+        throw e
+    }
   }
 
 }

--- a/linkis-commons/linkis-hadoop-common/src/test/scala/org/apache/linkis/hadoop/common/utils/HDFSUtilsKeytabCacheTest.scala
+++ b/linkis-commons/linkis-hadoop-common/src/test/scala/org/apache/linkis/hadoop/common/utils/HDFSUtilsKeytabCacheTest.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.linkis.hadoop.common.utils
+
+import java.util.concurrent.{ConcurrentHashMap, Executors, TimeUnit}
+
+import scala.collection.JavaConverters._
+
+import org.junit.jupiter.api.{Assertions, Test}
+
+class HDFSUtilsKeytabCacheTest {
+
+  private def getCreateKeytabCacheKeyMethod = {
+    val method =
+      HDFSUtils.getClass.getDeclaredMethod("createKeytabCacheKey", classOf[String], classOf[String])
+    method.setAccessible(true)
+    method
+  }
+
+  @Test
+  def testKeytabSuffixConstant: Unit = {
+    Assertions.assertNotNull(HDFSUtils.KEYTAB_SUFFIX)
+    Assertions.assertEquals(".keytab", HDFSUtils.KEYTAB_SUFFIX)
+  }
+
+  @Test
+  def testCreateKeytabCacheKeyWithNullLabel: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    // null label → key is just userName
+    val key = method.invoke(HDFSUtils, "testuser", null).asInstanceOf[String]
+    Assertions.assertEquals("testuser", key)
+  }
+
+  @Test
+  def testCreateKeytabCacheKeyWithLabel: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    // non-null label → key is "userName#label"
+    val key = method.invoke(HDFSUtils, "testuser", "cluster1").asInstanceOf[String]
+    Assertions.assertEquals("testuser#cluster1", key)
+  }
+
+  @Test
+  def testCreateKeytabCacheKeySameUserSameLabel: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    val key1 = method.invoke(HDFSUtils, "testuser", null).asInstanceOf[String]
+    val key2 = method.invoke(HDFSUtils, "testuser", null).asInstanceOf[String]
+    Assertions.assertEquals(key1, key2)
+  }
+
+  @Test
+  def testCreateKeytabCacheKeyDifferentUsers: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    val key1 = method.invoke(HDFSUtils, "user1", null).asInstanceOf[String]
+    val key2 = method.invoke(HDFSUtils, "user2", null).asInstanceOf[String]
+    Assertions.assertNotEquals(key1, key2)
+    Assertions.assertTrue(key1.contains("user1"))
+    Assertions.assertTrue(key2.contains("user2"))
+  }
+
+  @Test
+  def testCreateKeytabCacheKeyDifferentLabels: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    val key1 = method.invoke(HDFSUtils, "testuser", "cluster1").asInstanceOf[String]
+    val key2 = method.invoke(HDFSUtils, "testuser", "cluster2").asInstanceOf[String]
+    Assertions.assertNotEquals(key1, key2)
+    Assertions.assertTrue(key1.contains("cluster1"))
+    Assertions.assertTrue(key2.contains("cluster2"))
+  }
+
+  @Test
+  def testNullLabelDifferentFromDefaultLabel: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    // null label → "testuser", "default" label → "testuser#default", they are different
+    val key1 = method.invoke(HDFSUtils, "testuser", null).asInstanceOf[String]
+    val key2 = method.invoke(HDFSUtils, "testuser", "default").asInstanceOf[String]
+    Assertions.assertNotEquals(key1, key2)
+  }
+
+  @Test
+  def testConcurrentCreateKeytabCacheKey: Unit = {
+    val method = getCreateKeytabCacheKeyMethod
+    val userName = "testuser_concurrent"
+    val threadCount = 10
+
+    val executor = Executors.newFixedThreadPool(threadCount)
+    val resultKeys = new ConcurrentHashMap[String, String]()
+
+    try {
+      val futures = (0 until threadCount).map { _ =>
+        executor.submit(new Runnable {
+          override def run(): Unit = {
+            val key = method.invoke(HDFSUtils, userName, null).asInstanceOf[String]
+            resultKeys.put(key, key)
+          }
+        })
+      }
+      futures.foreach(_.get())
+    } finally {
+      executor.shutdown()
+      executor.awaitTermination(5, TimeUnit.SECONDS)
+    }
+
+    // null label → key is just userName, all threads should get the same key
+    Assertions.assertEquals(1, resultKeys.size())
+    Assertions.assertTrue(resultKeys.containsKey(userName))
+  }
+
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
When keytab authentication is enabled in cluster mode, the BML (BML Material Library) service experiences Out of Memory (OOM) exceptions. The issue is caused by inefficient HDFS operations that load entire file contents into memory when checking keytab file validity, leading to excessive memory consumption and eventual OOM errors.

**Purpose of Change:**
To address this OOM issue, this PR refactors the HDFS utility methods to use streaming and buffered reading instead of loading entire files into memory. The optimization focuses on keytab file validation and HDFS file operations, significantly reducing memory footprint during BML service operations.

**Value/Impact:**
After the change, BML service no longer experiences OOM errors when keytab is enabled in cluster mode, improving system stability and reducing service disruption risks.

### Related issues/PRs

Related issues: close #971
Related pr:none

### Brief change log

- Optimize HDFSUtils to use streaming instead of loading entire files
- Add configuration support for HDFS file reading buffer size
- Implement efficient keytab file validation without full file loading
- Add HDFSUtilsKeytabCacheTest for testing optimized keytab operations
- Update HadoopConf to support new buffer size configuration

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.