### PR TITLE
[feat][CGS][engineconn] add security parameters to command line when keytab is enabled

### DIFF
--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/conf/EnvConfiguration.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/conf/EnvConfiguration.scala
@@ -62,6 +62,12 @@ object EnvConfiguration {
     "Specify the option parameter of the java process (please modify it carefully!!!)"
   )
 
+  val ENGINE_CONN_KERBEROS_ENABLE = CommonVars(
+    "wds.linkis.keytab.enable",
+    false,
+    "Whether to enable Kerberos keytab, when enabled, will add -Dsun.net.inetaddr.ttl=0 -Dsun.security.jgss.native=false to engine JVM options"
+  )
+
   val ENGINE_CONN_JAVA_EXTRA_CLASSPATH = CommonVars(
     "wds.linkis.engineConn.extra.classpath",
     "",

--- a/linkis-computation-governance/linkis-engineconn/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
+++ b/linkis-computation-governance/linkis-engineconn/linkis-engineconn-plugin-core/src/main/scala/org/apache/linkis/manager/engineplugin/common/launch/process/JavaProcessEngineConnLaunchBuilder.scala
@@ -88,6 +88,10 @@ abstract class JavaProcessEngineConnLaunchBuilder
         .foreach(commandLine += _)
     }
     if (StringUtils.isNotEmpty(javaOPTS)) javaOPTS.split("\\s+").foreach(commandLine += _)
+    if (EnvConfiguration.ENGINE_CONN_KERBEROS_ENABLE.getValue) {
+      commandLine += "-Dsun.net.inetaddr.ttl=0"
+      commandLine += "-Dsun.security.jgss.native=false"
+    }
     getLogDir(engineConnBuildRequest).trim.split(" ").foreach(commandLine += _)
     commandLine += ("-Djava.io.tmpdir=" + variable(TEMP_DIRS))
     if (EnvConfiguration.ENGINE_CONN_DEBUG_ENABLE.getValue) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
When using keytab authentication, the engine launch process may expose sensitive security parameters. Without proper parameter protection, the keytab authentication process has security vulnerabilities that could lead to credential leakage.

**Purpose of Change:**
To address this problem, this PR adds security parameters to the Java command line when keytab authentication is enabled, ensuring secure credential handling during engine startup.

**Value/Impact:**
After the change, keytab-based authentication is more secure with sensitive parameters properly protected, reducing the risk of credential exposure during engine launch.

### Related issues/PRs

Related issues: close #1052
Related pr:none

### Brief change log

- Add security parameters to command line when keytab is enabled
- Update EnvConfiguration.java to include keytab security settings
- Update JavaProcessEngineConnLaunchBuilder.scala for secure parameter handling

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.