### PR TITLE
[fix][EC][spark] fix type conversion error in executor spark session retrieval

### DIFF
--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkDataCalcExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkDataCalcExecutor.scala
@@ -99,4 +99,6 @@ class SparkDataCalcExecutor(sparkEngineSession: SparkEngineSession, id: Long)
   override protected def getExecutorIdPreFix: String = "SparkDataCalcExecutor_"
 
   override protected def getKind: Kind = SparkDataCalc()
+
+  def getSparkEngineSession: SparkEngineSession = sparkEngineSession
 }

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkEngineConnExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkEngineConnExecutor.scala
@@ -225,13 +225,19 @@ abstract class SparkEngineConnExecutor(val sc: SparkContext, id: Long)
         // with unit if set configuration with unit
         // if not set sc get will get the value of spark.yarn.executor.memoryOverhead such as 512(without unit)
         val memoryOverhead = sc.getConf.get("spark.executor.memoryOverhead", "1G")
-        val pythonVersion = SparkConfiguration.SPARK_PYTHON_VERSION.getValue(
-          EngineConnObject.getEngineCreationContext.getOptions
-        )
+        val engineCreationOptions = EngineConnObject.getEngineCreationContext.getOptions
+        val pythonVersion = if (engineCreationOptions != null) {
+          SparkConfiguration.SPARK_PYTHON_VERSION.getValue(engineCreationOptions)
+        } else {
+          SparkConfiguration.SPARK_PYTHON_VERSION.getValue
+        }
         var engineType = ""
         val labels = engineExecutorContext.getLabels
         if (labels.length > 0) {
-          engineType = LabelUtil.getEngineTypeLabel(labels.toList.asJava).getStringValue
+          val engineTypeLabel = LabelUtil.getEngineTypeLabel(labels.toList.asJava)
+          if (engineTypeLabel != null) {
+            engineType = engineTypeLabel.getStringValue
+          }
         }
         val sb = new StringBuilder
         sb.append(s"spark.executor.instances=$executorNum\n")
@@ -330,13 +336,22 @@ abstract class SparkEngineConnExecutor(val sc: SparkContext, id: Long)
     var successCount = 0
     var failCount = 0
     logger.info(s"Spark executor params setting begin")
-    this
-      .asInstanceOf[SparkSqlExecutor]
-      .getSparkEngineSession
-      .sparkSession
-      .sessionState
-      .conf
-      .getAllConfs
+    val sparkSession = this match {
+      case executor: SparkSqlExecutor =>
+        executor.getSparkEngineSession
+      case executor: SparkScalaExecutor =>
+        executor.getSparkEngineSession
+      case executor: SparkPythonExecutor =>
+        executor.getSparkEngineSession
+      case executor: SparkDataCalcExecutor =>
+        executor.getSparkEngineSession
+      case _ =>
+        logger.warn(
+          s"Unsupported executor type: ${this.getClass.getName}, skip spark executor params setting"
+        )
+        return
+    }
+    sparkSession.sparkSession.sessionState.conf.getAllConfs
       .foreach { case (key, value) =>
         totalParams += 1
         if (excludeParams.contains(key)) {

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkPythonExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkPythonExecutor.scala
@@ -444,6 +444,7 @@ class SparkPythonExecutor(val sparkEngineSession: SparkEngineSession, val id: In
     }
   }
 
+  def getSparkEngineSession: SparkEngineSession = sparkEngineSession
 }
 
 case class PythonInterpretRequest(statements: String, jobGroup: String)

--- a/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkScalaExecutor.scala
+++ b/linkis-engineconn-plugins/spark/src/main/scala/org/apache/linkis/engineplugin/spark/executor/SparkScalaExecutor.scala
@@ -442,7 +442,7 @@ class SparkScalaExecutor(sparkEngineSession: SparkEngineSession, id: Long)
   }
 
   override protected def getExecutorIdPreFix: String = "SparkScalaExecutor_"
-
+  def getSparkEngineSession: SparkEngineSession = sparkEngineSession
 }
 
 class EngineExecutionContextFactory {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The SparkEngineConnExecutor code assumes all executors are SparkSqlExecutor and uses `asInstanceOf[SparkSqlExecutor]` to retrieve the SparkSession. This causes type conversion errors for other executor types like SparkScalaExecutor, SparkPythonExecutor, and SparkDataCalcExecutor when the spark executor params setting code is triggered.

**Purpose of Change:**
To address this problem, this PR adds a `getSparkEngineSession` method to each executor subclass (SparkSqlExecutor, SparkScalaExecutor, SparkPythonExecutor, SparkDataCalcExecutor) and uses pattern matching to safely retrieve the SparkSession based on the actual executor type.

**Value/Impact:**
After the change, all executor types can correctly retrieve their SparkSession without type conversion errors, improving system stability for Spark applications using Scala, Python, or DataCalc executors.

### Related issues/PRs

Related issues: close #1054
Related pr:none

### Brief change log

- Add getSparkEngineSession method to SparkScalaExecutor, SparkPythonExecutor, and SparkDataCalcExecutor
- Update SparkEngineConnExecutor to use pattern matching instead of direct casting
- Add null safety checks for engineCreationOptions and engineTypeLabel

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.