### PR TITLE
[perf][CGS][linkismanager] optimize slow sql in label relation query by using label id index

### DIFF
--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/dao/LabelManagerMapper.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/dao/LabelManagerMapper.java
@@ -116,6 +116,8 @@ public interface LabelManagerMapper {
   List<Map<String, Object>> getNodeRelationsByLabels(
       @Param("labels") List<PersistenceLabel> labels);
 
+  List<Map<String, Object>> getNodeRelationsByLabelIds(@Param("labelIds") List<Integer> labelIds);
+
   /**
    * 通过instance信息，同时返回instance信息和label信息
    *

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/persistence/impl/DefaultLabelManagerPersistence.java
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/java/org/apache/linkis/manager/persistence/impl/DefaultLabelManagerPersistence.java
@@ -298,11 +298,21 @@ public class DefaultLabelManagerPersistence implements LabelManagerPersistence {
     if (PersistenceUtils.persistenceLabelListIsEmpty(persistenceLabels))
       return Collections.emptyMap();
     try {
-      /*Map<String, Map<String, String>> keyValueMap = PersistenceUtils.filterEmptyPersistenceLabelList(persistenceLabels).stream().collect(Collectors.toMap(PersistenceLabel::getLabelKey, PersistenceLabel::getValue));
-      String dimType = Label.ValueRelation.ALL.name();
-      List<Map<String, Object>> nodeRelationsByLabels = labelManagerMapper.dimListNodeRelationsByKeyValueMap(keyValueMap, dimType);*/
+      // Step 1: 逐个通过 label_key + label_value 查询 label ID（走唯一索引，每次1行）
+      List<Integer> labelIds = new ArrayList<>();
+      for (PersistenceLabel label : persistenceLabels) {
+        PersistenceLabel dbLabel =
+            labelManagerMapper.getLabelByKeyValue(label.getLabelKey(), label.getStringValue());
+        if (dbLabel != null) {
+          labelIds.add(dbLabel.getId());
+        }
+      }
+      if (labelIds.isEmpty()) {
+        return Collections.emptyMap();
+      }
+      // Step 2: 用 label ID 列表查询关联关系（走主键 + idx_lid_instance 索引）
       List<Map<String, Object>> nodeRelationsByLabels =
-          labelManagerMapper.getNodeRelationsByLabels(persistenceLabels);
+          labelManagerMapper.getNodeRelationsByLabelIds(labelIds);
       List<Tunple<PersistenceLabel, ServiceInstance>> arrays =
           new ArrayList<Tunple<PersistenceLabel, ServiceInstance>>();
       for (Map<String, Object> nodeRelationsByLabel : nodeRelationsByLabels) {

--- a/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/resources/mapper/common/LabelManagerMapper.xml
+++ b/linkis-computation-governance/linkis-manager/linkis-manager-persistence/src/main/resources/mapper/common/LabelManagerMapper.xml
@@ -340,6 +340,24 @@
         </foreach>
     </select>
 
+    <select id="getNodeRelationsByLabelIds" resultType="java.util.HashMap">
+        SELECT
+        l.id,
+        l.label_value_size AS 'labelValueSize',
+        l.label_key AS 'labelKey',
+        l.label_value AS 'stringValue',
+        si.instance,
+        si.name AS 'applicationName'
+        FROM
+        linkis_cg_manager_label l
+        INNER JOIN linkis_cg_manager_label_service_instance lsi ON l.id = lsi.label_id
+        INNER JOIN linkis_cg_manager_service_instance si ON si.instance = lsi.service_instance
+        WHERE l.id IN
+        <foreach collection="labelIds" item="labelId" open="(" close=")" separator=",">
+            #{labelId}
+        </foreach>
+    </select>
+
     <select id="listResourceByLaBelId"
             resultType="org.apache.linkis.manager.common.entity.persistence.PersistenceResource">
         SELECT r.* FROM linkis_cg_manager_label_resource lr, linkis_cg_manager_linkis_resources r,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The existing SQL query for label relations in linkismanager does not efficiently utilize database indexes. The original implementation directly queries node relations by label key and value combinations, causing slow SQL performance when handling multiple labels, which affects overall system responsiveness.

**Purpose of Change:**
To address this problem, this PR optimizes the query strategy by splitting it into two steps: first querying label IDs using the unique index on (label_key, label_value), then querying node relations using the label ID list with primary key and instance indexes.

**Value/Impact:**
After the change, all database queries use appropriate indexes, significantly improving query performance for label relation lookups and reducing database load, especially in multi-tenant environments with frequent label queries.

### Related issues/PRs

Related issues: close #1057
Related pr:none

### Brief change log

- Add getNodeRelationsByLabelIds method to LabelManagerMapper interface
- Update DefaultLabelManagerPersistence to use two-step query strategy
- Add optimized SQL query in LabelManagerMapper.xml using label ID IN clause

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.