### PR TITLE
[fix][PES][datasource] fix oom error in partition statistic query by optimizing loop logic

### DIFF
--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/service/impl/MdqServiceImpl.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata/src/main/java/org/apache/linkis/metadata/service/impl/MdqServiceImpl.java
@@ -318,39 +318,37 @@ public class MdqServiceImpl implements MdqService {
   public List<MdqTablePartitionStatisticInfoVO> getMdqTablePartitionStatisticInfoVO(
       List<String> partitions, String partitionPath, String partitionSort) {
     // part_name(year=2020/day=0605) => MdqTablePartitionStatisticInfoVO 这里只是返回name，没有相关的分区统计数据
-    ArrayList<MdqTablePartitionStatisticInfoVO> statisticInfoVOS = new ArrayList<>();
+    List<MdqTablePartitionStatisticInfoVO> statisticInfoVOS = new ArrayList<>();
     Map<String, List<Tunple<String, String>>> partitionsStr =
         partitions.stream()
             .map(this::splitStrByFirstSlanting)
             .filter(Objects::nonNull) // 去掉null的
             .collect(Collectors.groupingBy(Tunple::getKey));
-    partitionsStr.forEach(
-        (k, v) -> {
-          MdqTablePartitionStatisticInfoVO mdqTablePartitionStatisticInfoVO =
-              new MdqTablePartitionStatisticInfoVO();
-          mdqTablePartitionStatisticInfoVO.setName(k);
-          String subPartitionPath = String.format("%s/%s", partitionPath, k);
-          mdqTablePartitionStatisticInfoVO.setPartitionPath(subPartitionPath);
-          List<String> subPartitions =
-              v.stream().map(Tunple::getValue).collect(Collectors.toList());
-          List<MdqTablePartitionStatisticInfoVO> childrens =
-              getMdqTablePartitionStatisticInfoVO(subPartitions, subPartitionPath, partitionSort);
-          // 排序
-          if ("asc".equals(partitionSort)) {
-            childrens =
-                childrens.stream()
-                    .sorted(Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName))
-                    .collect(Collectors.toList());
-          } else {
-            childrens =
-                childrens.stream()
-                    .sorted(
-                        Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName).reversed())
-                    .collect(Collectors.toList());
-          }
-          mdqTablePartitionStatisticInfoVO.setChildrens(childrens);
-          statisticInfoVOS.add(mdqTablePartitionStatisticInfoVO);
-        });
+    Comparator<MdqTablePartitionStatisticInfoVO> comparator =
+        "asc".equals(partitionSort)
+            ? Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName)
+            : Comparator.comparing(MdqTablePartitionStatisticInfoVO::getName).reversed();
+    for (Map.Entry<String, List<Tunple<String, String>>> entry : partitionsStr.entrySet()) {
+      MdqTablePartitionStatisticInfoVO mdqTablePartitionStatisticInfoVO =
+          new MdqTablePartitionStatisticInfoVO();
+      mdqTablePartitionStatisticInfoVO.setName(entry.getKey());
+      String subPartitionPath = String.format("%s/%s", partitionPath, entry.getKey());
+      mdqTablePartitionStatisticInfoVO.setPartitionPath(subPartitionPath);
+      List<String> subPartitions =
+          entry.getValue().stream()
+              .map(Tunple::getValue)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
+      if (subPartitions.isEmpty()) {
+        mdqTablePartitionStatisticInfoVO.setChildrens(new ArrayList<>());
+      } else {
+        List<MdqTablePartitionStatisticInfoVO> childrens =
+            getMdqTablePartitionStatisticInfoVO(subPartitions, subPartitionPath, partitionSort);
+        childrens.sort(comparator);
+        mdqTablePartitionStatisticInfoVO.setChildrens(childrens);
+      }
+      statisticInfoVOS.add(mdqTablePartitionStatisticInfoVO);
+    }
     return statisticInfoVOS;
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The existing partition statistic query logic in MdqServiceImpl uses functional programming with forEach and multiple stream operations. When handling tables with hundreds or thousands of partitions, this approach creates excessive intermediate objects and repeatedly instantiates Comparators, leading to OutOfMemoryError and service instability.

**Purpose of Change:**
To address this problem, this PR replaces the functional programming approach with traditional for loops, extracts Comparator creation outside the loop, adds null filtering and empty checks, and uses direct sort() instead of stream().sorted().collect() for better memory efficiency.

**Value/Impact:**
After the change, the partition statistic query can handle large numbers of partitions without OOM errors, improving system stability and reducing memory footprint during metadata queries, especially for databases with extensive partitioning.

### Related issues/PRs

Related issues: close #1059
Related pr:none

### Brief change log

- Replace forEach with traditional for loop in getMdqTablePartitionStatisticInfoVO method
- Extract Comparator creation outside the loop to avoid repeated instantiation
- Add Objects::nonNull filter for subPartitions stream
- Add isEmpty check to avoid unnecessary recursive calls
- Use sort() instead of stream().sorted().collect() for better memory efficiency

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.