### PR TITLE
[feat][EC][jdbc] add db2 database support with validation query mapping

### DIFF
--- a/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/ConnectionManager.java
+++ b/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/ConnectionManager.java
@@ -20,6 +20,7 @@ package org.apache.linkis.manager.engineplugin.jdbc;
 import org.apache.linkis.common.utils.AESUtils;
 import org.apache.linkis.common.utils.SecurityUtils;
 import org.apache.linkis.hadoop.common.utils.KerberosUtils;
+import org.apache.linkis.manager.engineplugin.jdbc.conf.JDBCConfiguration;
 import org.apache.linkis.manager.engineplugin.jdbc.constant.JDBCEngineConnConstant;
 import org.apache.linkis.manager.engineplugin.jdbc.exception.JDBCParamsIllegalException;
 import org.apache.linkis.manager.engineplugin.jdbc.utils.JdbcParamUtils;
@@ -52,6 +53,9 @@ public class ConnectionManager {
   private final Map<String, DataSource> dataSourceFactories;
   private final JDBCDataSourceConfigurations jdbcDataSourceConfigurations;
 
+  // Cache for validation query mapping parsed from configuration
+  private volatile Map<String, String> validationQueryMapping = null;
+
   private static volatile ConnectionManager connectionManager; // NOSONAR
   private ScheduledExecutorService scheduledExecutorService;
   private Integer kinitFailCount = 0;
@@ -59,6 +63,54 @@ public class ConnectionManager {
   private ConnectionManager() {
     jdbcDataSourceConfigurations = new JDBCDataSourceConfigurations();
     dataSourceFactories = new HashMap<>();
+    initValidationQueryMapping();
+  }
+
+  /**
+   * Parse validation query mapping from configuration. Format: dbType1:query1,dbType2:query2,...
+   * Example: oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1
+   */
+  private void initValidationQueryMapping() {
+    String mappingConfig = JDBCConfiguration.JDBC_VALIDATION_QUERY_MAPPING();
+    Map<String, String> mapping = new HashMap<>();
+    if (StringUtils.isNotBlank(mappingConfig)) {
+      String[] entries = mappingConfig.split(",");
+      for (String entry : entries) {
+        String[] parts = entry.split(":");
+        if (parts.length == 2) {
+          String dbType = parts[0].trim().toLowerCase();
+          String query = parts[1].trim();
+          mapping.put(dbType, query);
+          LOG.info("Loaded validation query mapping: {} -> {}", dbType, query);
+        }
+      }
+    }
+    this.validationQueryMapping = mapping;
+  }
+
+  /**
+   * Get validation query for a specific JDBC URL based on database type. Returns null if no
+   * specific mapping found (will use default "SELECT 1").
+   *
+   * @param jdbcUrl the JDBC connection URL
+   * @return the validation query for this database type, or null if using default
+   */
+  private String getValidationQueryFromUrl(String jdbcUrl) {
+    if (jdbcUrl == null || validationQueryMapping == null || validationQueryMapping.isEmpty()) {
+      return null;
+    }
+    String lowerUrl = jdbcUrl.toLowerCase();
+    for (Map.Entry<String, String> entry : validationQueryMapping.entrySet()) {
+      if (lowerUrl.contains(entry.getKey())) {
+        LOG.debug(
+            "Using validation query '{}' for database type '{}' from URL: {}",
+            entry.getValue(),
+            entry.getKey(),
+            jdbcUrl);
+        return entry.getValue();
+      }
+    }
+    return null;
   }
 
   public static ConnectionManager getInstance() {
@@ -188,9 +240,13 @@ public class ConnectionManager {
     DruidDataSource datasource = new DruidDataSource();
     LOG.info("Database connection address information(数据库连接地址信息)=" + dbUrl);
     datasource.setUrl(dbUrl);
-    if (dbUrl.toLowerCase().contains("oracle")) {
-      datasource.setValidationQuery("SELECT 1 FROM DUAL");
+
+    // Set validation query based on database type from configuration
+    String dbSpecificValidationQuery = getValidationQueryFromUrl(dbUrl);
+    if (dbSpecificValidationQuery != null) {
+      datasource.setValidationQuery(dbSpecificValidationQuery);
     }
+
     datasource.setUsername(username);
     if (AESUtils.LINKIS_DATASOURCE_AES_SWITCH.getValue()) {
       // decrypt
@@ -227,9 +283,13 @@ public class ConnectionManager {
         }
       }
     }
-    if (url.contains("oracle")) {
-      ((DruidDataSource) dataSource).setValidationQuery("SELECT 1 FROM DUAL");
+
+    // Set validation query based on database type from configuration
+    String dbSpecificValidationQuery = getValidationQueryFromUrl(url);
+    if (dbSpecificValidationQuery != null) {
+      ((DruidDataSource) dataSource).setValidationQuery(dbSpecificValidationQuery);
     }
+
     return dataSource.getConnection();
   }
 

--- a/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/constant/JDBCEngineConnConstant.java
+++ b/linkis-engineconn-plugins/jdbc/src/main/java/org/apache/linkis/manager/engineplugin/jdbc/constant/JDBCEngineConnConstant.java
@@ -57,6 +57,12 @@ public class JDBCEngineConnConstant {
   public static final String JDBC_POOL_TEST_WHILE_IDLE = "wds.linkis.jdbc.pool.testWhileIdle";
   public static final String JDBC_POOL_VALIDATION_QUERY = "wds.linkis.jdbc.pool.validationQuery";
   public static final String JDBC_POOL_DEFAULT_VALIDATION_QUERY = "SELECT 1";
+
+  // Configuration for database-specific validation queries
+  // Format: dbType1:query1,dbType2:query2,...
+  // Example: oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1,mysql:SELECT 1
+  public static final String JDBC_VALIDATION_QUERY_MAPPING =
+      "wds.linkis.jdbc.validation.query.mapping";
   public static final String JDBC_POOL_TIME_BETWEEN_MIN_EVIC_IDLE_MS =
       "wds.linkis.jdbc.pool.minEvictableIdleTimeMillis";
   public static final String JDBC_POOL_TIME_BETWEEN_EVIC_RUNS_MS =

--- a/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/conf/JDBCConfiguration.scala
+++ b/linkis-engineconn-plugins/jdbc/src/main/scala/org/apache/linkis/manager/engineplugin/jdbc/conf/JDBCConfiguration.scala
@@ -43,4 +43,13 @@ object JDBCConfiguration {
   val SUPPORT_CONN_PARAM_EXECUTE_ENABLE: Boolean =
     CommonVars[Boolean]("linkis.support.conn.param.execute.enable", true).getValue
 
+  // Validation query mapping for different database types
+  // Format: dbType1:query1,dbType2:query2,...
+  // Default includes common databases that need non-standard validation queries
+  val JDBC_VALIDATION_QUERY_MAPPING: String =
+    CommonVars[String](
+      "wds.linkis.jdbc.validation.query.mapping",
+      "oracle:SELECT 1 FROM DUAL,db2:SELECT 1 FROM SYSIBM.SYSDUMMY1"
+    ).getValue
+
 }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
@@ -44,6 +44,11 @@ public class SqlConnection implements Closeable {
   private static final CommonVars<String> SQL_CONNECT_URL =
       CommonVars.apply("wds.linkis.server.mdm.service.db2.url", "jdbc:db2://%s:%s/%s");
 
+  private static final CommonVars<String> SQL_SCHEMA_QUERY =
+      CommonVars.apply(
+          "wds.linkis.server.mdm.service.db2.schema.query.sql",
+          "SELECT SCHEMANAME FROM SYSCAT.SCHEMATA WHERE SCHEMANAME NOT LIKE 'SYS%' AND SCHEMANAME NOT IN ('NULLID', 'SQLJ') WITH UR");
+
   private Connection conn;
 
   private ConnectMessage connectMessage;
@@ -67,14 +72,15 @@ public class SqlConnection implements Closeable {
   }
 
   public List<String> getAllDatabases() throws SQLException {
-    // Query schema list from system catalog view
+    // Query schema list from system catalog view with system schema filtering
     List<String> schemaNames = new ArrayList<>();
     Statement stmt = null;
     ResultSet rs = null;
     try {
       stmt = conn.createStatement();
-      // Query all schemas from SYSCAT.SCHEMATA (DB2 system catalog)
-      rs = stmt.executeQuery("SELECT SCHEMANAME FROM SYSCAT.SCHEMATA WITH UR");
+      // Use configurable SQL to query schemas from SYSCAT.SCHEMATA
+      // Default query filters out system schemas (SYS%, NULLID, SQLJ)
+      rs = stmt.executeQuery(SQL_SCHEMA_QUERY.getValue());
       while (rs.next()) {
         schemaNames.add(rs.getString(1));
       }

--- a/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
+++ b/linkis-public-enhancements/linkis-datasource/linkis-metadata-query/service/jdbc/src/main/java/org/apache/linkis/metadata/query/service/db2/SqlConnection.java
@@ -67,22 +67,21 @@ public class SqlConnection implements Closeable {
   }
 
   public List<String> getAllDatabases() throws SQLException {
-    // db2 "select schemaname from syscat.schemata"
-    List<String> dataBaseName = new ArrayList<>();
+    // Query schema list from system catalog view
+    List<String> schemaNames = new ArrayList<>();
     Statement stmt = null;
     ResultSet rs = null;
     try {
       stmt = conn.createStatement();
-      rs = stmt.executeQuery("list database directory");
-      // rs = stmt.executeQuery("SELECT * FROM SYSIBMADM.APPLICATIONS WITH UR");
-      // rs = stmt.executeQuery("select * from syscat.tables");
+      // Query all schemas from SYSCAT.SCHEMATA (DB2 system catalog)
+      rs = stmt.executeQuery("SELECT SCHEMANAME FROM SYSCAT.SCHEMATA WITH UR");
       while (rs.next()) {
-        dataBaseName.add(rs.getString(1));
+        schemaNames.add(rs.getString(1));
       }
     } finally {
       closeResource(null, stmt, rs);
     }
-    return dataBaseName;
+    return schemaNames;
   }
 
   public List<String> getAllTables(String tabschema) throws SQLException {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Apache Linkis here: https://linkis.apache.org/community/how-to-contribute
Happy contributing!
-->

### What is the purpose of the change

**Background/Problem:**
The Linkis JDBC engine currently lacks proper support for DB2 database. The default validation query `SELECT 1` does not work for DB2, which requires `SELECT 1 FROM SYSIBM.SYSDUMMY1` for connection validation. Additionally, the schema query logic in SqlConnection uses incorrect DB2 system catalog syntax, causing schema listing failures.

**Purpose of Change:**
To address this problem, this PR adds a configurable validation query mapping mechanism that supports database-specific validation queries, with default mappings for Oracle and DB2, and updates the DB2 schema query to use the correct SYSCAT.SCHEMATA system catalog view.

**Value/Impact:**
After the change, DB2 database connections work properly with correct validation queries, improving connection reliability and stability. Users can now successfully use DB2 databases with Linkis JDBC engine, and the system can be easily extended to support other databases with non-standard validation queries.

### Related issues/PRs

Related issues: close #1063
Related pr:none

### Brief change log

- Add JDBC_VALIDATION_QUERY_MAPPING configuration constant to JDBCEngineConnConstant
- Add JDBC_VALIDATION_QUERY_MAPPING to JDBCConfiguration with default Oracle and DB2 mappings
- Add initValidationQueryMapping and getValidationQueryFromUrl methods to ConnectionManager
- Update ConnectionManager to use database-specific validation queries from mapping
- Fix DB2 SqlConnection to use correct SYSCAT.SCHEMATA query for schema listing

### Checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://linkis.apache.org/community/how-to-contribute).
- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible
- [ ] **If this is a code change**: I have written unit tests to fully verify the new behavior.